### PR TITLE
Various small fixes

### DIFF
--- a/godot_ap/ui/console/base_console.gd
+++ b/godot_ap/ui/console/base_console.gd
@@ -160,9 +160,9 @@ func _ready():
 		v.italic = true
 		return
 	if parts_cont:
-		parts_cont.child_entered_tree.connect(_on_new_message)
+		parts_cont.child_entered_tree.connect(_on_new_message.unbind(1))
 
-func _on_new_message(node: Node) -> void:
+func _on_new_message() -> void:
 	if scroll_to_bottom_on_new_message:
 		scroll_bottom()
 

--- a/godot_ap/ui/console/base_console.gd
+++ b/godot_ap/ui/console/base_console.gd
@@ -200,6 +200,9 @@ func _gui_input(event):
 					scroll_by_abs(-size.y)
 				KEY_PAGEDOWN:
 					scroll_by_abs(size.y)
+				_:
+					return
+			accept_event()
 
 func queue_locked_redraw() -> void:
 	is_max_scroll = false

--- a/godot_ap/ui/console/base_console.gd
+++ b/godot_ap/ui/console/base_console.gd
@@ -54,7 +54,7 @@ func pop_dropdown(target: Control) -> VBoxContainer:
 	target.resized.connect(resize_window)
 	window.add_child(vbox)
 	window.ready.connect(resize_window)
-	#window.tree_exiting.connect(func(): resized.disconnect(resize_window))
+	window.tree_exiting.connect(target.resized.disconnect.bind(resize_window))
 	add_child.call_deferred(window) # Defer adding it, to allow caller to add things to the vbox
 	vbox.set_anchors_preset(Control.PRESET_FULL_RECT)
 	return vbox

--- a/godot_ap/ui/console/base_console.gd
+++ b/godot_ap/ui/console/base_console.gd
@@ -160,9 +160,9 @@ func _ready():
 		v.italic = true
 		return
 	if parts_cont:
-		parts_cont.child_entered_tree.connect(_on_new_message.unbind(1))
+		parts_cont.child_entered_tree.connect(_on_new_message)
 
-func _on_new_message() -> void:
+func _on_new_message(_node: Node) -> void:
 	if scroll_to_bottom_on_new_message:
 		scroll_bottom()
 

--- a/godot_ap/ui/typing_bar.gd
+++ b/godot_ap/ui/typing_bar.gd
@@ -74,7 +74,7 @@ func _gui_input(event):
 				KEY_TAB:
 					if _tab_completions:
 						update_text(_tab_completions[0])
-					accept_event()
+						accept_event()
 				KEY_UP:
 					history_step(-1)
 					accept_event()

--- a/godot_ap/ui/updown_lineedit.gd
+++ b/godot_ap/ui/updown_lineedit.gd
@@ -5,10 +5,10 @@ func _gui_input(event):
 		var n: Control
 		match event.keycode:
 			KEY_UP:
-				n = get_node(focus_neighbor_top) as Control
+				n = get_node_or_null(focus_neighbor_top)
 			KEY_DOWN:
-				n = get_node(focus_neighbor_bottom) as Control
-		if n:
+				n = get_node_or_null(focus_neighbor_bottom)
+		if n is Control:
 			accept_event()
 			if event.pressed and not event.is_echo():
 				release_focus()

--- a/godot_ap/ui/updown_lineedit.gd
+++ b/godot_ap/ui/updown_lineedit.gd
@@ -5,10 +5,10 @@ func _gui_input(event):
 		var n: Control
 		match event.keycode:
 			KEY_UP:
-				n = get_node_or_null(focus_neighbor_top)
+				n = get_node_or_null(focus_neighbor_top) as Control
 			KEY_DOWN:
-				n = get_node_or_null(focus_neighbor_bottom)
-		if n is Control:
+				n = get_node_or_null(focus_neighbor_bottom) as Control
+		if n:
 			accept_event()
 			if event.pressed and not event.is_echo():
 				release_focus()


### PR DESCRIPTION
I've fixed some obscure little issues
 - Prevent an error when updown_lineedit's focus neighbors are unbound
 - Setting events handled for scrolling console and tab completing
 - Remove unused argument from _on_new_message to avoid a warning in some environments
 - Disconnect resize_window function when hint priority popup is freed, otherwise it will crash if you resize the window after setting a hint priority