### PR TITLE
Adding documentation and smoothing out formatting for non-UI code.

### DIFF
--- a/godot_ap/ap_files/ap_location.gd
+++ b/godot_ap/ap_files/ap_location.gd
@@ -1,12 +1,10 @@
 class_name APLocation
 ## A multiworld location.
 
-## The location's id.
+## The location's ID.
 var id: int
-
 ## The location's name.
 var name: String
-
 ## Priority of the location as given by a hint.
 var hint_status: NetworkHint.Status
 

--- a/godot_ap/ap_files/ap_location.gd
+++ b/godot_ap/ap_files/ap_location.gd
@@ -1,20 +1,33 @@
 class_name APLocation
+## A multiworld location.
 
+## The location's id.
 var id: int
+
+## The location's name.
 var name: String
+
+## Priority of the location as given by a hint.
 var hint_status: NetworkHint.Status
 
+
+## Static factory method.
 static func make(locid: int) -> APLocation:
 	var ret := APLocation.new()
 	ret.id = locid
-	ret.name = Archipelago.conn.get_gamedata_for_player().get_loc_name(locid)
+	# TODO: Remove this or fix it, as Archipelago was renamed to AP and conn doesn't exist.
+	ret.name = Archipelago.conn.get_gamedata_for_player().get_loc_name(locid) 
 	return ret
+
+
+## Create empty and invalid location.
 static func nil() -> APLocation:
 	var ret := APLocation.new()
 	ret.id = -9999
 	ret.name = "INVALID"
 	ret.hint_status = NetworkHint.Status.UNSPECIFIED
 	return ret
+
 
 func _to_string() -> String:
 	return "LOCATION(%d '%s',Hint '%s')" % [id, name, NetworkHint.status_names[hint_status]]

--- a/godot_ap/ap_files/ap_location.gd
+++ b/godot_ap/ap_files/ap_location.gd
@@ -15,7 +15,6 @@ var hint_status: NetworkHint.Status
 static func make(locid: int) -> APLocation:
 	var ret := APLocation.new()
 	ret.id = locid
-	# TODO: Remove this or fix it, as Archipelago was renamed to AP and conn doesn't exist.
 	ret.name = Archipelago.conn.get_gamedata_for_player().get_loc_name(locid) 
 	return ret
 

--- a/godot_ap/ap_files/ap_location.gd
+++ b/godot_ap/ap_files/ap_location.gd
@@ -15,7 +15,7 @@ var hint_status: NetworkHint.Status
 static func make(locid: int) -> APLocation:
 	var ret := APLocation.new()
 	ret.id = locid
-	ret.name = Archipelago.conn.get_gamedata_for_player().get_loc_name(locid) 
+	ret.name = Archipelago.conn.get_gamedata_for_player().get_loc_name(locid)
 	return ret
 
 

--- a/godot_ap/ap_files/ap_lock.gd
+++ b/godot_ap/ap_files/ap_lock.gd
@@ -4,9 +4,9 @@ extends Node
 
 ## Whether or not the lock is valid.
 var valid: bool = false
-## The id of the player.
+## The ID of the player.
 var player_id: int = 0
-## The id of the team.
+## The ID of the team.
 var team_id: int = 0
 ## The name of the slot the player connects to.
 var slot_name: String = ""
@@ -28,13 +28,13 @@ func lock(conn: ConnectionInfo) -> Array[String]:
 		return []
 	var ret: Array[String] = []
 	if player_id != conn.player_id:
-		ret.append("Wrong player_id: %d != %d" % [player_id,conn.player_id])
+		ret.append("Wrong player_id: %d != %d" % [player_id, conn.player_id])
 	if team_id != conn.team_id:
-		ret.append("Wrong team_id: %d != %d" % [team_id,conn.team_id])
+		ret.append("Wrong team_id: %d != %d" % [team_id, conn.team_id])
 	if slot_name != conn.get_slot(player_id).name:
-		ret.append("Wrong slot_name: %s != %s" % [slot_name,conn.get_slot(player_id).name])
+		ret.append("Wrong slot_name: %s != %s" % [slot_name, conn.get_slot(player_id).name])
 	if seed_name != conn.seed_name:
-		ret.append("Wrong seed_name: %s != %s" % [seed_name,conn.seed_name])
+		ret.append("Wrong seed_name: %s != %s" % [seed_name, conn.seed_name])
 	return ret
 
 
@@ -73,4 +73,4 @@ func write(file: FileAccess) -> bool:
 func _to_string():
 	if not valid:
 		return "APLOCK()"
-	return "APLOCK(%d,%d,%s,%s)" % [player_id,team_id,slot_name,seed_name]
+	return "APLOCK(%d,%d,%s,%s)" % [player_id, team_id, slot_name, seed_name]

--- a/godot_ap/ap_files/ap_lock.gd
+++ b/godot_ap/ap_files/ap_lock.gd
@@ -1,12 +1,23 @@
-class_name APLock extends Node
+class_name APLock 
+extends Node
 ## Data unique to a room connection, locking a save to only connect to the same room.
 
+## Whether or not the lock is valid.
 var valid: bool = false
+## The id of the player.
 var player_id: int = 0
+## The id of the team.
 var team_id: int = 0
+## The name of the slot the player connects to.
 var slot_name: String = ""
+## The name of the seed.
 var seed_name: String = ""
 
+
+## Check if [param conn] meets the requirements of this lock. Returns an array containing any
+## invalid parameters on the connection. If everything matches the array will be empty.
+## [br][br]
+## If [member valid] is [code]false[/code] all members will be set to the values of [param conn].
 func lock(conn: ConnectionInfo) -> Array[String]:
 	if not valid:
 		player_id = conn.player_id
@@ -25,12 +36,19 @@ func lock(conn: ConnectionInfo) -> Array[String]:
 	if seed_name != conn.seed_name:
 		ret.append("Wrong seed_name: %s != %s" % [seed_name,conn.seed_name])
 	return ret
+
+
+## Release the lock, invalidating it.
 func unlock() -> void:
 	valid = false
 
+
+## Read lock information from [param file]. Returns [code]false[/code] if errors occur reading
+## from [param file], and [code]true[/code] otherwise, even if the lock isn't valid.
 func read(file: FileAccess) -> bool:
 	valid = file.get_8()
-	if not valid: return true
+	if not valid:
+		return true
 	player_id = file.get_32()
 	team_id = file.get_32()
 	slot_name = file.get_line()
@@ -38,15 +56,21 @@ func read(file: FileAccess) -> bool:
 	if file.get_error():
 		return false
 	return true
+
+
+## Write lock information to [param file].
 func write(file: FileAccess) -> bool:
 	file.store_8(1 if valid else 0)
-	if not valid: return true
+	if not valid:
+		return true
 	file.store_32(player_id)
 	file.store_32(team_id)
 	file.store_line(slot_name)
 	file.store_line(seed_name)
 	return true
 
+
 func _to_string():
-	if not valid: return "APLOCK()"
+	if not valid:
+		return "APLOCK()"
 	return "APLOCK(%d,%d,%s,%s)" % [player_id,team_id,slot_name,seed_name]

--- a/godot_ap/ap_files/connect_creds.gd
+++ b/godot_ap/ap_files/connect_creds.gd
@@ -7,24 +7,21 @@ signal updated(creds: APCredentials)
 
 ## The host to connect to.
 var ip: String = "archipelago.gg"
-
 ## The port to connect to. If left empty will default to [code]"38281"[/code].
 var port: String = "" :
 	get:
 		if port.is_empty():
 			return "38281"
 		return port
-
 ## The slot name to connect to.
 var slot: String = ""
-
 ## The room password.
 var pwd: String = ""
 
 
 ## Read saved credentials from [param file].
 func read(file: FileAccess) -> bool:
-	var new_strs = [file.get_line(),file.get_line(),file.get_line(),file.get_line()]
+	var new_strs = [file.get_line(), file.get_line(), file.get_line(), file.get_line()]
 	if file.get_error():
 		return false
 	ip = new_strs[0]
@@ -54,4 +51,4 @@ func update(nip: String, nport: String, nslot: String, npwd: String = ""):
 
 
 func _to_string():
-	return "APCREDS(%s:%s,%s,%s)" % [ip,port,slot,pwd]
+	return "APCREDS(%s:%s,%s,%s)" % [ip, port, slot, pwd]

--- a/godot_ap/ap_files/connect_creds.gd
+++ b/godot_ap/ap_files/connect_creds.gd
@@ -1,16 +1,28 @@
-class_name APCredentials extends Node
+class_name APCredentials
+extends Node
+## Credentials for connecting to an Archipelago room
 
+## Emits updated credentials when credentials are changed.
 signal updated(creds: APCredentials)
 
+## The host to connect to.
 var ip: String = "archipelago.gg"
+
+## The port to connect to. If left empty will default to [code]"38281"[/code].
 var port: String = "" :
 	get:
 		if port.is_empty():
 			return "38281"
-		return  port
+		return port
+
+## The slot name to connect to.
 var slot: String = ""
+
+## The room password.
 var pwd: String = ""
 
+
+## Read saved credentials from [param file].
 func read(file: FileAccess) -> bool:
 	var new_strs = [file.get_line(),file.get_line(),file.get_line(),file.get_line()]
 	if file.get_error():
@@ -21,6 +33,9 @@ func read(file: FileAccess) -> bool:
 	pwd = new_strs[3]
 	updated.emit(self)
 	return true
+
+
+## Write credentials to [param file].
 func write(file: FileAccess) -> bool:
 	file.store_line(ip)
 	file.store_line(port)
@@ -28,6 +43,8 @@ func write(file: FileAccess) -> bool:
 	file.store_line(pwd)
 	return true
 
+
+## Update credentials.
 func update(nip: String, nport: String, nslot: String, npwd: String = ""):
 	ip = nip
 	port = nport
@@ -35,6 +52,6 @@ func update(nip: String, nport: String, nslot: String, npwd: String = ""):
 	pwd = npwd
 	updated.emit(self)
 
+
 func _to_string():
 	return "APCREDS(%s:%s,%s,%s)" % [ip,port,slot,pwd]
-

--- a/godot_ap/ap_files/connection_info.gd
+++ b/godot_ap/ap_files/connection_info.gd
@@ -227,8 +227,8 @@ func _on_retrieve(json: Dictionary) -> void:
 		_retrieve_queue[key] = []
 
 ## Sends an [code]UpdateHint[/code] packet, updating the status of an existing hint
-## The hint is identified by [param loc], [param plyr], the location it is for and the player who
-## needs to find it.
+## The hint is identified by [param loc], [param plyr], which are the ids for the location it is for
+## and the player who needs to find it respectively.
 func update_hint(loc: int, plyr: int, status: NetworkHint.Status) -> void:
 	Archipelago.send_command("UpdateHint", {"location": loc, "player": plyr, "status": status})
 

--- a/godot_ap/ap_files/connection_info.gd
+++ b/godot_ap/ap_files/connection_info.gd
@@ -1,34 +1,38 @@
 class_name ConnectionInfo
 ## Data representing a connection to the Archipelago server.
 ##
-## Each new connection will be sent via the 'Archipelago.connected' signal.
-## As each connection is a new object, any connections to signals of this class will automatically be cleaned up upon disconnecting.
-
+## Each new connection will be sent via the [signal Archipelago.connected] signal.
+## As each connection is a new object, any connections to signals of this class will automatically 
+## be cleaned up upon disconnecting.
 
 # Variables / data
-## The server's Archipelago version
+## The server's Archipelago version.
 var serv_version: Version 
-## The generator's Archipelago version
+
+## The generator's Archipelago version.
 var gen_version: Version 
 
-## The seed_name received from the server
+## The seed name received from the server.
 var seed_name: String 
 
-## The ID of your player
+## The ID of your player.
 var player_id: int 
-## The ID of your team (unimplemented)
+
+## The ID of your team (unimplemented).
 var team_id: int 
 
-## The slot_data from the server
+## The slot data from the server.
 var slot_data: Dictionary 
 
-## The players in this Multiworld
+## The players in this Multiworld.
 var players: Array[NetworkPlayer] 
-## The slots in this Multiworld
+
+## The slots in this Multiworld.
 var slots: Array[NetworkSlot] 
 
 ## The checked status of the locations for this slot, by location ID.
 var slot_locations: Dictionary[int, bool] = {}
+
 ## The NetworkItems received from the server, in index order.
 var received_items: Array[NetworkItem] = []
 
@@ -40,12 +44,12 @@ var hints: Array[NetworkHint] = [] :
 			Call 'set_hint_notify()' or 'install_hint_listenter()' first!""")
 		return hints
 
-## All locations, by ID
+## All locations, by ID.
 var locations: Dictionary[int, APLocation] = {}
-## All locations, by name
+
+## All locations, by name.
 var locs_by_name: Dictionary[String, APLocation] = {}
 
-# Init / Getters
 
 func _received_index(index: int) -> bool:
 	return received_items.size() > index and received_items[index] != null
@@ -54,45 +58,46 @@ func _received_index(index: int) -> bool:
 func _to_string():
 	return "AP_CONN(SERV_%s, GEN_%s, SEED:%s, PLYR %d, TEAM %d, SLOT_DATA %s)" % [serv_version,gen_version,seed_name,player_id,team_id,slot_data]
 
-
-## Returns a NetworkPlayer for the given ID (or the current slot)
-## TODO: Handle teams
+# TODO: Handle teams
+## Returns the player for the given ID (or the current slot).
 func get_player(id: int = -1) -> NetworkPlayer:
-	if id < 0: return players[player_id-1]
+	if id < 0:
+		return players[player_id-1]
 	return players[id-1]
 	
-	
-## Returns a NetworkSlot for the given ID (or the current slot)
-## TODO: Handle teams
+# TODO: Handle teams
+## Returns the slot for the given ID (or the current slot).
 func get_slot(id: int = -1) -> NetworkSlot:
-	if id < 0: return slots[player_id-1]
+	if id < 0:
+		return slots[player_id-1]
 	return slots[id-1]
 	
 	
-## Returns a player's name for the given ID (or the current slot)
-## If [param alias] is [code]false[/code], will return the slot name regardless of alias
+## Returns a player's name for the given ID (or the current slot).
+## If [param alias] is [code]false[/code], will return the slot name regardless of alias.
 func get_player_name(plyr_id: int = -1, alias := true) -> String:
 	var name = get_player(plyr_id).get_name(alias)
-	if not name: name = "Player %d" % plyr_id
+	if not name:
+		name = "Player %d" % plyr_id
 	return name
 	
 	
-## Returns the game name for the given player ID (or the current slot)
+## Returns the game name for the given player ID (or the current slot).
 func get_game_for_player(plyr_id: int = -1) -> String:
 	return get_slot(plyr_id).game
 	
 	
-## Returns the DataCache for the given player ID (or the current slot)
+## Returns the DataCache for the given player ID (or the current slot).
 func get_gamedata_for_player(plyr_id: int = -1) -> DataCache:
 	return AP.get_datacache(get_game_for_player(plyr_id))
 
 
-## Returns the APLocation (name + id + current hint status) for the given location ID
+## Returns the APLocation (name + id + current hint status) for the given location ID.
 func get_location(locid: int) -> APLocation:
 	return locations.get(locid, APLocation.nil())
 	
 	
-## Returns the APLocation (name + id + current hint status) for the given location name
+## Returns the APLocation (name + id + current hint status) for the given location name.
 func get_loc_by_name(loc_name: String) -> APLocation:
 	return locs_by_name.get(loc_name, APLocation.nil())
 
@@ -112,30 +117,37 @@ func _load_locations() -> void:
 @warning_ignore_start("unused_signal")
 ## Emitted when a [code]Bounce[/code] packet is received.
 signal bounce(json: Dictionary)
+
 ## Emitted when a [code]Bounce[/code] packet of type [code]DeathLink[/code] is received.
 ## Sent after [signal bounce].
 signal deathlink(source: String, cause: String, json: Dictionary)
+
 ## Emitted when a [code]Bounce[/code] packet of type [code]TrapLink[/code] is received. Sent after 
 ## [signal bounce].
 ## [param trap_name] will be the trap name AFTER resolving the received name through 
 ## [member AP.TRAP_LINK_ALIASES].
 signal traplink(source: String, trap_name: String, json: Dictionary)
 
-## Emitted when a [code]SetReply[/code] packet is received
+## Emitted when a [code]SetReply[/code] packet is received.
 signal setreply(json: Dictionary)
-## Emitted when a [code]RoomUpdate[/code] packet is received
+
+## Emitted when a [code]RoomUpdate[/code] packet is received.
 signal roomupdate(json: Dictionary)
-## Emitted for each item received
+
+## Emitted for each item received.
 signal obtained_item(item: NetworkItem)
-## Emitted for each item *packet* received
+
+## Emitted for each item [i]packet[/i] received.
 signal obtained_items(items: Array[NetworkItem])
-## Emitted when the server re-sends ALL obtained items
+
+## Emitted when the server re-sends ALL obtained items.
 signal refresh_items(items: Array[NetworkItem])
+
 ## Used as part of the [method set_hint_notify] / [method install_hint_listener] functions.
 ## Use [method set_hint_notify] instead of connecting to this signal directly.
 signal _on_hint_update(hints: Array[NetworkHint])
 
-## Emitted when a scout packet containing ALL locations is received (see [method force_scout_all])
+## Emitted when a scout packet containing ALL locations is received (see [method force_scout_all]).
 signal all_scout_cached
 @warning_ignore_restore("unused_signal")
 
@@ -147,7 +159,8 @@ var _hint_listening: bool = false
 
 ## Tell the server to send us information about the hints for this slot.
 func install_hint_listener() -> void:
-	if _hint_listening: return
+	if _hint_listening:
+		return
 	_hint_listening = true
 	var hint_str := "_read_hints_%d_%d" % [team_id, player_id]
 	set_notify(hint_str, _load_hints_from_json)
@@ -161,10 +174,10 @@ func _load_hints_from_json(new_hints: Array) -> void:
 	hints.make_read_only()
 	_on_hint_update.emit(hints)
 
-# TODO: Wording in the second section could flow more naturally
+
 ## Connects the [Callable] [param proc] to be called every time hints are updated for this client.
 ## [br][br]
-## Calls [param proc] if hints are already loaded, otherwise requests all hints
+## Calls [param proc] if hints are already loaded. Otherwise requests all hints
 ## from the server, which will trigger an update.
 ## [br][br]
 ## [param proc] must accept an [Array] of [NetworkHint]s as its first parameter, and
@@ -233,7 +246,8 @@ func scout(location: int, create_as_hint: int, proc: Callable) -> void:
 	var item: NetworkItem = _scout_cache.get(location)
 	if create_as_hint or not item: # Always send if `create_as_hint`!
 		Archipelago.send_command("LocationScouts", {"locations": [location], "create_as_hint": create_as_hint})
-	if not proc: return
+	if not proc:
+		return
 	if item:
 		proc.call(item)
 	else:
@@ -254,7 +268,7 @@ func _on_locinfo(json: Dictionary) -> void:
 		all_scout_cached.emit()
 		
 		
-## Scouts every location into the local cache
+## Scouts every location into the local cache.
 func force_scout_all() -> void: 
 	Archipelago.send_command("LocationScouts", {"locations": slot_locations.keys(), "create_as_hint": 0})
 
@@ -268,7 +282,8 @@ func send_bounce(data: Dictionary, target_games: Array[String], target_slots: Ar
 		cmd["slots"] = target_slots
 	if target_tags:
 		cmd["tags"] = target_tags
-	if not cmd: return
+	if not cmd:
+		return
 	cmd.merge(data)
 	Archipelago.send_command("Bounce", cmd)
 

--- a/godot_ap/ap_files/connection_info.gd
+++ b/godot_ap/ap_files/connection_info.gd
@@ -8,34 +8,24 @@ class_name ConnectionInfo
 # Variables / data
 ## The server's Archipelago version.
 var serv_version: Version 
-
 ## The generator's Archipelago version.
 var gen_version: Version 
-
 ## The seed name received from the server.
 var seed_name: String 
-
 ## The ID of your player.
 var player_id: int 
-
 ## The ID of your team (unimplemented).
 var team_id: int 
-
 ## The slot data from the server.
 var slot_data: Dictionary 
-
 ## The players in this Multiworld.
 var players: Array[NetworkPlayer] 
-
 ## The slots in this Multiworld.
 var slots: Array[NetworkSlot] 
-
 ## The checked status of the locations for this slot, by location ID.
 var slot_locations: Dictionary[int, bool] = {}
-
 ## The NetworkItems received from the server, in index order.
 var received_items: Array[NetworkItem] = []
-
 ## The hints for this slot.
 var hints: Array[NetworkHint] = [] :
 	get:
@@ -43,10 +33,8 @@ var hints: Array[NetworkHint] = [] :
 			AP.warn("""Tried to access hint information, but the client isn't listening for hints from the server!
 			Call 'set_hint_notify()' or 'install_hint_listenter()' first!""")
 		return hints
-
 ## All locations, by ID.
 var locations: Dictionary[int, APLocation] = {}
-
 ## All locations, by name.
 var locs_by_name: Dictionary[String, APLocation] = {}
 
@@ -56,21 +44,24 @@ func _received_index(index: int) -> bool:
 
 
 func _to_string():
-	return "AP_CONN(SERV_%s, GEN_%s, SEED:%s, PLYR %d, TEAM %d, SLOT_DATA %s)" % [serv_version,gen_version,seed_name,player_id,team_id,slot_data]
+	return "AP_CONN(SERV_%s, GEN_%s, SEED:%s, PLYR %d, TEAM %d, SLOT_DATA %s)" % \
+			[serv_version, gen_version, seed_name, player_id, team_id, slot_data]
+
 
 # TODO: Handle teams
 ## Returns the player for the given ID (or the current slot).
 func get_player(id: int = -1) -> NetworkPlayer:
 	if id < 0:
-		return players[player_id-1]
-	return players[id-1]
-	
+		return players[player_id - 1]
+	return players[id - 1]
+
+
 # TODO: Handle teams
 ## Returns the slot for the given ID (or the current slot).
 func get_slot(id: int = -1) -> NetworkSlot:
 	if id < 0:
-		return slots[player_id-1]
-	return slots[id-1]
+		return slots[player_id - 1]
+	return slots[id - 1]
 	
 	
 ## Returns a player's name for the given ID (or the current slot).
@@ -92,12 +83,12 @@ func get_gamedata_for_player(plyr_id: int = -1) -> DataCache:
 	return AP.get_datacache(get_game_for_player(plyr_id))
 
 
-## Returns the APLocation (name + id + current hint status) for the given location ID.
+## Returns the APLocation (name + ID + current hint status) for the given location ID.
 func get_location(locid: int) -> APLocation:
 	return locations.get(locid, APLocation.nil())
 	
 	
-## Returns the APLocation (name + id + current hint status) for the given location name.
+## Returns the APLocation (name + ID + current hint status) for the given location name.
 func get_loc_by_name(loc_name: String) -> APLocation:
 	return locs_by_name.get(loc_name, APLocation.nil())
 
@@ -117,40 +108,30 @@ func _load_locations() -> void:
 @warning_ignore_start("unused_signal")
 ## Emitted when a [code]Bounce[/code] packet is received.
 signal bounce(json: Dictionary)
-
 ## Emitted when a [code]Bounce[/code] packet of type [code]DeathLink[/code] is received.
 ## Sent after [signal bounce].
 signal deathlink(source: String, cause: String, json: Dictionary)
-
 ## Emitted when a [code]Bounce[/code] packet of type [code]TrapLink[/code] is received. Sent after 
 ## [signal bounce].
 ## [param trap_name] will be the trap name AFTER resolving the received name through 
 ## [member AP.TRAP_LINK_ALIASES].
 signal traplink(source: String, trap_name: String, json: Dictionary)
-
 ## Emitted when a [code]SetReply[/code] packet is received.
 signal setreply(json: Dictionary)
-
 ## Emitted when a [code]RoomUpdate[/code] packet is received.
 signal roomupdate(json: Dictionary)
-
 ## Emitted for each item received.
 signal obtained_item(item: NetworkItem)
-
 ## Emitted for each item [i]packet[/i] received.
 signal obtained_items(items: Array[NetworkItem])
-
 ## Emitted when the server re-sends ALL obtained items.
 signal refresh_items(items: Array[NetworkItem])
-
 ## Used as part of the [method set_hint_notify] / [method install_hint_listener] functions.
 ## Use [method set_hint_notify] instead of connecting to this signal directly.
 signal _on_hint_update(hints: Array[NetworkHint])
-
 ## Emitted when a scout packet containing ALL locations is received (see [method force_scout_all]).
 signal all_scout_cached
 @warning_ignore_restore("unused_signal")
-
 
 # Outgoing server packets
 var _notified_keys: Dictionary[String, bool] = {}
@@ -197,7 +178,7 @@ func set_hint_notify(proc: Callable) -> void:
 ## parameters. Any returned values will be ignored.
 func set_notify(key: String, proc: Callable) -> void:
 	if not _notified_keys.has(key):
-		Archipelago.send_command("SetNotify", {"keys": [key]})
+		Archipelago.send_command("SetNotify", { "keys": [key] })
 		_notified_keys[key] = true
 	setreply.connect(func(json):
 		if json["key"] == key:
@@ -213,7 +194,7 @@ var _retrieve_queue: Dictionary[String, Array]
 ## [param proc] must accept a value of type [Variant] as its first paremeter, and need no other
 ## parameters. Any returned values will be ignored.
 func retrieve(key: String, proc: Callable) -> void:
-	Archipelago.send_command("Get", {"keys": [key]})
+	Archipelago.send_command("Get", { "keys": [key] })
 	if not _retrieve_queue.has(key):
 		_retrieve_queue[key] = [proc]
 	else: _retrieve_queue[key].append(proc)
@@ -226,11 +207,13 @@ func _on_retrieve(json: Dictionary) -> void:
 			proc.call(vals[key])
 		_retrieve_queue[key] = []
 
+
 ## Sends an [code]UpdateHint[/code] packet, updating the status of an existing hint
-## The hint is identified by [param loc], [param plyr], which are the ids for the location it is for
+## The hint is identified by [param loc], [param plyr], which are the IDs for the location it is for
 ## and the player who needs to find it respectively.
 func update_hint(loc: int, plyr: int, status: NetworkHint.Status) -> void:
-	Archipelago.send_command("UpdateHint", {"location": loc, "player": plyr, "status": status})
+	Archipelago.send_command("UpdateHint", { "location": loc, "player": plyr, "status": status })
+
 
 var _scout_cache: Dictionary[int, NetworkItem]
 var _scout_queue: Dictionary[int, Array]
@@ -245,7 +228,8 @@ var _scout_queue: Dictionary[int, Array]
 func scout(location: int, create_as_hint: int, proc: Callable) -> void:
 	var item: NetworkItem = _scout_cache.get(location)
 	if create_as_hint or not item: # Always send if `create_as_hint`!
-		Archipelago.send_command("LocationScouts", {"locations": [location], "create_as_hint": create_as_hint})
+		Archipelago.send_command("LocationScouts",
+				{ "locations": [location], "create_as_hint": create_as_hint })
 	if not proc:
 		return
 	if item:
@@ -270,11 +254,17 @@ func _on_locinfo(json: Dictionary) -> void:
 		
 ## Scouts every location into the local cache.
 func force_scout_all() -> void: 
-	Archipelago.send_command("LocationScouts", {"locations": slot_locations.keys(), "create_as_hint": 0})
+	Archipelago.send_command("LocationScouts",
+			{ "locations": slot_locations.keys(), "create_as_hint": 0 })
 
 
 ## Sends a [code]Bounce[/code] packet with the provided parameters.
-func send_bounce(data: Dictionary, target_games: Array[String], target_slots: Array[String], target_tags: Array[String]) -> void:
+func send_bounce(
+	data: Dictionary,
+	target_games: Array[String],
+	target_slots: Array[String],
+	target_tags: Array[String]
+) -> void:
 	var cmd: Dictionary = {}
 	if target_games:
 		cmd["games"] = target_games

--- a/godot_ap/ap_files/connection_info.gd
+++ b/godot_ap/ap_files/connection_info.gd
@@ -14,7 +14,7 @@ var gen_version: Version
 var seed_name: String 
 ## The ID of your player.
 var player_id: int 
-## The ID of your team (unimplemented).
+## The ID of your team.
 var team_id: int 
 ## The slot data from the server.
 var slot_data: Dictionary 
@@ -33,6 +33,7 @@ var hints: Array[NetworkHint] = [] :
 			AP.warn("""Tried to access hint information, but the client isn't listening for hints from the server!
 			Call 'set_hint_notify()' or 'install_hint_listenter()' first!""")
 		return hints
+
 ## All locations, by ID.
 var locations: Dictionary[int, APLocation] = {}
 ## All locations, by name.
@@ -122,9 +123,11 @@ signal setreply(json: Dictionary)
 signal roomupdate(json: Dictionary)
 ## Emitted for each item received.
 signal obtained_item(item: NetworkItem)
-## Emitted for each item [i]packet[/i] received.
+## Emitted for each item [i]packet[/i] received, after [signal obtained_item]
+## is emitted for each individual item.
 signal obtained_items(items: Array[NetworkItem])
-## Emitted when the server re-sends ALL obtained items.
+## Emitted when the server re-sends ALL obtained items, after
+## [signal obtained_items] fires.
 signal refresh_items(items: Array[NetworkItem])
 ## Used as part of the [method set_hint_notify] / [method install_hint_listener] functions.
 ## Use [method set_hint_notify] instead of connecting to this signal directly.

--- a/godot_ap/ap_files/connection_info.gd
+++ b/godot_ap/ap_files/connection_info.gd
@@ -1,25 +1,34 @@
+class_name ConnectionInfo
 ## Data representing a connection to the Archipelago server.
 ##
 ## Each new connection will be sent via the 'Archipelago.connected' signal.
 ## As each connection is a new object, any connections to signals of this class will automatically be cleaned up upon disconnecting.
-class_name ConnectionInfo
+
 
 # Variables / data
+## The server's Archipelago version
+var serv_version: Version 
+## The generator's Archipelago version
+var gen_version: Version 
 
-var serv_version: Version ## The server's Archipelago version
-var gen_version: Version ## The generator's Archipelago version
-var seed_name: String ## The seed_name received from the server
+## The seed_name received from the server
+var seed_name: String 
 
-var player_id: int ## The ID of your player
-var team_id: int ## The ID of your team (unimplemented)
-var slot_data: Dictionary ## The slot_data from the server
+## The ID of your player
+var player_id: int 
+## The ID of your team (unimplemented)
+var team_id: int 
 
-var players: Array[NetworkPlayer] ## The players in this Multiworld
-var slots: Array[NetworkSlot] ## The slots in this Multiworld
+## The slot_data from the server
+var slot_data: Dictionary 
+
+## The players in this Multiworld
+var players: Array[NetworkPlayer] 
+## The slots in this Multiworld
+var slots: Array[NetworkSlot] 
 
 ## The checked status of the locations for this slot, by location ID.
 var slot_locations: Dictionary[int, bool] = {}
-
 ## The NetworkItems received from the server, in index order.
 var received_items: Array[NetworkItem] = []
 
@@ -41,38 +50,52 @@ var locs_by_name: Dictionary[String, APLocation] = {}
 func _received_index(index: int) -> bool:
 	return received_items.size() > index and received_items[index] != null
 
+
 func _to_string():
 	return "AP_CONN(SERV_%s, GEN_%s, SEED:%s, PLYR %d, TEAM %d, SLOT_DATA %s)" % [serv_version,gen_version,seed_name,player_id,team_id,slot_data]
+
 
 ## Returns a NetworkPlayer for the given ID (or the current slot)
 ## TODO: Handle teams
 func get_player(id: int = -1) -> NetworkPlayer:
 	if id < 0: return players[player_id-1]
 	return players[id-1]
+	
+	
 ## Returns a NetworkSlot for the given ID (or the current slot)
 ## TODO: Handle teams
 func get_slot(id: int = -1) -> NetworkSlot:
 	if id < 0: return slots[player_id-1]
 	return slots[id-1]
+	
+	
 ## Returns a player's name for the given ID (or the current slot)
-## If `alias` is false, will return the slot name regardless of alias
+## If [param alias] is [code]false[/code], will return the slot name regardless of alias
 func get_player_name(plyr_id: int = -1, alias := true) -> String:
 	var name = get_player(plyr_id).get_name(alias)
 	if not name: name = "Player %d" % plyr_id
 	return name
+	
+	
 ## Returns the game name for the given player ID (or the current slot)
 func get_game_for_player(plyr_id: int = -1) -> String:
 	return get_slot(plyr_id).game
+	
+	
 ## Returns the DataCache for the given player ID (or the current slot)
 func get_gamedata_for_player(plyr_id: int = -1) -> DataCache:
 	return AP.get_datacache(get_game_for_player(plyr_id))
 
+
 ## Returns the APLocation (name + id + current hint status) for the given location ID
 func get_location(locid: int) -> APLocation:
 	return locations.get(locid, APLocation.nil())
+	
+	
 ## Returns the APLocation (name + id + current hint status) for the given location name
 func get_loc_by_name(loc_name: String) -> APLocation:
 	return locs_by_name.get(loc_name, APLocation.nil())
+
 
 # Loads (or reloads) all locations from the datapackage.
 func _load_locations() -> void:
@@ -84,19 +107,23 @@ func _load_locations() -> void:
 		locations[locid] = loc
 		locs_by_name[loc.name] = loc
 
+
 # Incoming server packets
 @warning_ignore_start("unused_signal")
-## Emitted when a `Bounce` packet is received.
+## Emitted when a [code]Bounce[/code] packet is received.
 signal bounce(json: Dictionary)
-## Emitted when a `Bounce` packet of type `DeathLink` is received, after the `bounce` signal.
+## Emitted when a [code]Bounce[/code] packet of type [code]DeathLink[/code] is received.
+## Sent after [signal bounce].
 signal deathlink(source: String, cause: String, json: Dictionary)
-## Emitted when a `Bounce` packet of type `TrapLink` is received, after the `bounce` signal.
-## 'trap_name' will be the trap name AFTER resolving the received name through `TRAP_LINK_ALIASES`.
+## Emitted when a [code]Bounce[/code] packet of type [code]TrapLink[/code] is received. Sent after 
+## [signal bounce].
+## [param trap_name] will be the trap name AFTER resolving the received name through 
+## [member AP.TRAP_LINK_ALIASES].
 signal traplink(source: String, trap_name: String, json: Dictionary)
 
-## Emitted when a `SetReply` packet is received
+## Emitted when a [code]SetReply[/code] packet is received
 signal setreply(json: Dictionary)
-## Emitted when a `RoomUpdate` packet is received
+## Emitted when a [code]RoomUpdate[/code] packet is received
 signal roomupdate(json: Dictionary)
 ## Emitted for each item received
 signal obtained_item(item: NetworkItem)
@@ -104,16 +131,20 @@ signal obtained_item(item: NetworkItem)
 signal obtained_items(items: Array[NetworkItem])
 ## Emitted when the server re-sends ALL obtained items
 signal refresh_items(items: Array[NetworkItem])
-## Used as part of the `set_hint_notify()` / `install_hint_listener()` functions.
-## Use `set_hint_notify()` instead of connecting to this signal directly.
+## Used as part of the [method set_hint_notify] / [method install_hint_listener] functions.
+## Use [method set_hint_notify] instead of connecting to this signal directly.
 signal _on_hint_update(hints: Array[NetworkHint])
 
-## Emitted when a scout packet containing ALL locations is received (see `force_scout_all`)
+## Emitted when a scout packet containing ALL locations is received (see [method force_scout_all])
 signal all_scout_cached
 @warning_ignore_restore("unused_signal")
+
+
 # Outgoing server packets
 var _notified_keys: Dictionary[String, bool] = {}
 var _hint_listening: bool = false
+
+
 ## Tell the server to send us information about the hints for this slot.
 func install_hint_listener() -> void:
 	if _hint_listening: return
@@ -121,6 +152,8 @@ func install_hint_listener() -> void:
 	var hint_str := "_read_hints_%d_%d" % [team_id, player_id]
 	set_notify(hint_str, _load_hints_from_json)
 	retrieve(hint_str, _load_hints_from_json)
+
+
 func _load_hints_from_json(new_hints: Array) -> void:
 	hints = []
 	for json in new_hints:
@@ -128,16 +161,27 @@ func _load_hints_from_json(new_hints: Array) -> void:
 	hints.make_read_only()
 	_on_hint_update.emit(hints)
 
-
-## Connects the specified `Callable(Array[NetworkHint])->void` to be called every time
-## hints are updated for this client. Will call immediately, if hints are already loaded;
-## else will immediately call for hints to be loaded, which will trigger an update.
+# TODO: Wording in the second section could flow more naturally
+## Connects the [Callable] [param proc] to be called every time hints are updated for this client.
+## [br][br]
+## Calls [param proc] if hints are already loaded, otherwise requests all hints
+## from the server, which will trigger an update.
+## [br][br]
+## [param proc] must accept an [Array] of [NetworkHint]s as its first parameter, and
+## need no other parameters. Any returned values will be ignored.
 func set_hint_notify(proc: Callable) -> void:
 	_on_hint_update.connect(proc)
-	if _hint_listening: proc.call(hints)
-	else: install_hint_listener()
-## Sends a `SetNotify` packet, and connects the specified `Callable(Variant)->void`
-## to be called every time the specified `key` is updated on the server.
+	if _hint_listening: 
+		proc.call(hints)
+	else: 
+		install_hint_listener()
+
+
+## Sends a [code]SetNotify[/code] packet, and connects [param proc] to be called every time the 
+## specified [param key] is updated on the server.
+## [br][br]
+## [param proc] must accept a value of type [Variant] as its first parameter, and need no other
+## parameters. Any returned values will be ignored.
 func set_notify(key: String, proc: Callable) -> void:
 	if not _notified_keys.has(key):
 		Archipelago.send_command("SetNotify", {"keys": [key]})
@@ -146,14 +190,22 @@ func set_notify(key: String, proc: Callable) -> void:
 		if json["key"] == key:
 			proc.call(json.get("value")))
 
+# Queue of keys to retrieve values of from the server.
 var _retrieve_queue: Dictionary[String, Array]
-## Sends a `Get` packet, and connects the specified `Callable(Variant)->void`
-## to be called once when the result is retrieved
+
+
+## Sends a [code]Get[/code] packet, and connects [param proc] to be called once when the result is 
+## retrieved.
+## [br][br]
+## [param proc] must accept a value of type [Variant] as its first paremeter, and need no other
+## parameters. Any returned values will be ignored.
 func retrieve(key: String, proc: Callable) -> void:
 	Archipelago.send_command("Get", {"keys": [key]})
 	if not _retrieve_queue.has(key):
 		_retrieve_queue[key] = [proc]
 	else: _retrieve_queue[key].append(proc)
+	
+	
 func _on_retrieve(json: Dictionary) -> void:
 	var vals: Dictionary = json.get("keys", {})
 	for key in vals.keys():
@@ -161,16 +213,22 @@ func _on_retrieve(json: Dictionary) -> void:
 			proc.call(vals[key])
 		_retrieve_queue[key] = []
 
-## Sends an `UpdateHint` packet, updating the status of an existing hint
-## The hint is identified by `loc, plyr`, the location it is for and the player who is to find it
+## Sends an [code]UpdateHint[/code] packet, updating the status of an existing hint
+## The hint is identified by [param loc], [param plyr], the location it is for and the player who
+## needs to find it.
 func update_hint(loc: int, plyr: int, status: NetworkHint.Status) -> void:
 	Archipelago.send_command("UpdateHint", {"location": loc, "player": plyr, "status": status})
 
 var _scout_cache: Dictionary[int, NetworkItem]
 var _scout_queue: Dictionary[int, Array]
-## Sends a `LocationScouts` packet, and connects the specified `Callable(NetworkItem)->void`
+
+
+## Sends a [code]LocationScouts[/code] packet, and connects [param proc]
 ## to be called with the returned information.
 ## If the location has already been scouted this session, returns the cached info.
+## [br][br]
+## [param proc] must accpet a value of [NetworkItem] as its first parameter, and need no other
+## parameters. Any returned values will be ignored.
 func scout(location: int, create_as_hint: int, proc: Callable) -> void:
 	var item: NetworkItem = _scout_cache.get(location)
 	if create_as_hint or not item: # Always send if `create_as_hint`!
@@ -182,6 +240,8 @@ func scout(location: int, create_as_hint: int, proc: Callable) -> void:
 		if not _scout_queue.has(location):
 			_scout_queue[location] = [proc]
 		else: _scout_queue[location].append(proc)
+		
+		
 func _on_locinfo(json: Dictionary) -> void:
 	var locs = json.get("locations", [])
 	for loc in locs:
@@ -192,10 +252,14 @@ func _on_locinfo(json: Dictionary) -> void:
 		_scout_queue.erase(locid)
 	if locs.size() == slot_locations.size():
 		all_scout_cached.emit()
-func force_scout_all() -> void: ## Scouts every location into the local cache
+		
+		
+## Scouts every location into the local cache
+func force_scout_all() -> void: 
 	Archipelago.send_command("LocationScouts", {"locations": slot_locations.keys(), "create_as_hint": 0})
 
-## Sends a `Bounce` packet with whatever information you like
+
+## Sends a [code]Bounce[/code] packet with the provided parameters.
 func send_bounce(data: Dictionary, target_games: Array[String], target_slots: Array[String], target_tags: Array[String]) -> void:
 	var cmd: Dictionary = {}
 	if target_games:
@@ -208,8 +272,9 @@ func send_bounce(data: Dictionary, target_games: Array[String], target_slots: Ar
 	cmd.merge(data)
 	Archipelago.send_command("Bounce", cmd)
 
-## Sends a `Bounce` packet designed for the `DeathLink` feature
-## Requires `DeathLink` being enabled (see 'Archipelago.set_deathlink()')
+
+## Sends a [code]Bounce[/code] packet designed for the DeathLink feature
+## Requires DeathLink being enabled, see [method AP.set_deathlink]
 ## Only players in the same DeathLink group will be killed.
 func send_deathlink(cause: String = ""):
 	if not Archipelago.is_deathlink():
@@ -223,8 +288,9 @@ func send_deathlink(cause: String = ""):
 	cmd["data"]["time"] = Archipelago.last_sent_deathlink_time
 	send_bounce(cmd, [], [], [Archipelago.get_deathlink_tag()])
 
-## Sends a `Bounce` packet designed for the `TrapLink` feature
-## Requires the client be connected with the `TrapLink` tag
+
+## Sends a [code]Bounce[/code] packet designed for the TrapLink feature
+## Requires the client be connected with the [code]TrapLink[/code] tag
 func send_traplink(trap_name: String):
 	if not Archipelago.is_traplink():
 		AP.log("Tried to send TrapLink while TrapLink is not enabled!")

--- a/godot_ap/ap_files/connection_info.gd
+++ b/godot_ap/ap_files/connection_info.gd
@@ -10,13 +10,13 @@ class_name ConnectionInfo
 var serv_version: Version 
 ## The generator's Archipelago version.
 var gen_version: Version 
-## The seed name received from the server.
+## The [code]seed_name[/code] received from the server.
 var seed_name: String 
 ## The ID of your player.
 var player_id: int 
 ## The ID of your team.
 var team_id: int 
-## The slot data from the server.
+## The [code]slot_data[/code] from the server.
 var slot_data: Dictionary 
 ## The players in this Multiworld.
 var players: Array[NetworkPlayer] 

--- a/godot_ap/ap_files/connection_info.gd
+++ b/godot_ap/ap_files/connection_info.gd
@@ -283,7 +283,8 @@ func send_bounce(
 
 ## Sends a [code]Bounce[/code] packet designed for the DeathLink feature
 ## Requires DeathLink being enabled, see [method AP.set_deathlink]
-## Only players in the same DeathLink group will be killed.
+## Only players in the same DeathLink group will be killed, see
+## [member AP.deathlink_group].
 func send_deathlink(cause: String = ""):
 	if not Archipelago.is_deathlink():
 		AP.log("Tried to send DeathLink while DeathLink is not enabled!")
@@ -298,7 +299,7 @@ func send_deathlink(cause: String = ""):
 
 
 ## Sends a [code]Bounce[/code] packet designed for the TrapLink feature
-## Requires the client be connected with the [code]TrapLink[/code] tag
+## Requires TrapLink being enabled, see [method AP.set_traplink].
 func send_traplink(trap_name: String):
 	if not Archipelago.is_traplink():
 		AP.log("Tried to send TrapLink while TrapLink is not enabled!")

--- a/godot_ap/ap_files/console_command.gd
+++ b/godot_ap/ap_files/console_command.gd
@@ -4,6 +4,7 @@ class_name ConsoleCommand
 ## How deep the indentation is for help text display on the console.
 const HELPTEXT_INDENT = 20
 
+
 ## Contains the help text for the usage of a command.
 class CmdHelpText:
 	## The arguments the command takes, to be displayed to the user.
@@ -15,6 +16,7 @@ class CmdHelpText:
 	## [br][br]
 	## Should require no parameters and return a [bool].
 	var cond: Callable # Callable() -> bool
+
 
 ## The command in question (including preceding [code]/[/code] or [code]![/code]).
 var text: String = ""
@@ -39,6 +41,7 @@ var autofill_proc: Variant = null # Callable(String)->Array[String] | null
 ## [br][br]
 ## Entries should require no parameters and return a [bool].
 var disabled_procs: Array[Callable] = [] # Callable()->bool
+
 var _debug: bool = false
 
 #region Constructor and builder-pattern funcs
@@ -104,7 +107,8 @@ func is_debug() -> bool:
 func get_helptext() -> String:
 	var s := ""
 	for ht in help_text:
-		if ht.cond and not ht.cond.call(): continue
+		if ht.cond and not ht.cond.call():
+			continue
 		s += "%s %s\n    %s\n" % [text, ht.args, ht.text.replace("\n","\n    ")]
 	return s
 
@@ -122,21 +126,18 @@ func output_helptext(console: BaseConsole, target = null) -> void:
 		
 	if not target:
 		for ht in texts:
-			console.add(BaseConsole.make_text(
-					"%s %s" % [text, ht.args],
+			console.add(BaseConsole.make_text("%s %s" % [text, ht.args],
 					"",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			var indent := BaseConsole.make_indent(HELPTEXT_INDENT)
 			console.add(indent)
-			indent.add_child(BaseConsole.make_text(
-					ht.text,
+			indent.add_child(BaseConsole.make_text(ht.text,
 					"",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			
 	elif target is ConsoleFoldableContainer:
 		for ht in texts:
-			target.add(BaseConsole.make_text(
-					"%s %s" % [text, ht.args],
+			target.add(BaseConsole.make_text("%s %s" % [text, ht.args],
 					"",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			target.add(console.make_header_spacing(0))
@@ -144,22 +145,19 @@ func output_helptext(console: BaseConsole, target = null) -> void:
 			target.add(indent)
 			var vbox := VBoxContainer.new()
 			indent.add_child(vbox)
-			vbox.add_child(BaseConsole.make_text(
-					ht.text,
+			vbox.add_child(BaseConsole.make_text(ht.text,
 					"",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			vbox.add_child(console.make_header_spacing(0))
 
 	elif target is Container:
 		for ht in texts:
-			target.add_child(BaseConsole.make_text(
-					"%s %s" % [text, ht.args],
+			target.add_child(BaseConsole.make_text("%s %s" % [text, ht.args],
 					"",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			target.add_child(console.make_header_spacing(0))
 			target.add_child(BaseConsole.make_indent(HELPTEXT_INDENT))
-			target.add_child(BaseConsole.make_text(
-					ht.text,
+			target.add_child(BaseConsole.make_text(ht.text,
 					"",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			target.add_child(console.make_header_spacing(0))
@@ -168,8 +166,7 @@ func output_helptext(console: BaseConsole, target = null) -> void:
 
 ## Output usage instructions to [param console].
 func output_usage(console: BaseConsole) -> void:
-	console.add(BaseConsole.make_text(
-			"Usage:\n%s" % get_helptext(),
+	console.add(BaseConsole.make_text("Usage:\n%s" % get_helptext(),
 			"",
 			AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 

--- a/godot_ap/ap_files/console_command.gd
+++ b/godot_ap/ap_files/console_command.gd
@@ -1,94 +1,187 @@
 class_name ConsoleCommand
+## Information about a console command.
 
+## How deep the indentation is for help text display on the console.
 const HELPTEXT_INDENT = 20
 
+## Contains the help text for the usage of a command.
 class CmdHelpText:
+	## The arguments the command takes, to be displayed to the user.
 	var args: String = ""
+	## A description of the command and the uses of the variables.
 	var text: String = ""
-	var cond: Callable #Callable[]->bool
+	## A [Callable] that returns [code]true[/code] if the help text should be displayed. Returns
+	## [code]false[/code] otherwise.
+	## [br][br]
+	## Should require no parameters and return a [bool].
+	var cond: Callable # Callable() -> bool
 
+## The command in question (including preceding [code]/[/code] or [code]![/code]).
 var text: String = ""
+## An array of descriptions to inform the user of how to use this command. Different elements may
+## describe variations on commands with different argument types or counts. See
+## [ConsoleCommand.CmdHelpText] for more information.
 var help_text: Array[CmdHelpText] = []
+## A [Callable] to be called when the command is input. May be [code]null[/code].
+## [br][br]
+## Must take a [ConsoleCommand] as its first parameter and a [String] as its second. The second
+## parameter contains all arguments passed to the command. Any returned values will be ignored.
 var call_proc: Variant = null # Callable(ConsoleCommand,String)->void | null
+## A [Callable] that returns autofill information as an [Array] of [String]s. May be 
+## [code]null[/code].
+## [br][br]
+## Should take a [String] as its first parameter and return an [Array] of [String]s. The parameter
+## contains the current input by the user, and the returned value contains an array of possible
+## completions
 var autofill_proc: Variant = null # Callable(String)->Array[String] | null
-var disabled_procs: Array[Callable] = [] # [Callable()->bool]
+## An [Array] of [Callable]s that determine whether or not this command is disabled. If any return
+## [code]true[/code], this command is considered disabled.
+## [br][br]
+## Entries should require no parameters and return a [bool].
+var disabled_procs: Array[Callable] = [] # Callable()->bool
 var _debug: bool = false
 
 #region Constructor and builder-pattern funcs
 func _init(txt: String):
 	text = txt
 
+
+## Set [member call_proc].
 func set_call(caller: Callable) -> ConsoleCommand:
 	call_proc = caller
 	return self
+
+
+## Set [member autofill_proc].
 func set_autofill(caller: Variant) -> ConsoleCommand:
 	assert(caller is bool or caller is Callable)
 	autofill_proc = caller
 	return self
+
+
+## Register a [ConsoleCommand.CmdHelpText] to [member help_text]. [param args] should be a text
+## display of the arguments to the command and [param helptxt] should be a description of the
+## command's effects.
 func add_help(args: String, helptxt: String) -> ConsoleCommand:
 	var ht := CmdHelpText.new()
 	ht.args = args
 	ht.text = helptxt
 	help_text.append(ht)
 	return self
+
+
+## Register a [ConsoleCommand.CmdHelpText] to [member help_text]. Similar to [method add_help], but
+## takes an additional [param cond] parameter to determine if the help text should be displayed.
+## [br][br]
+## See [member ConsoleCommand.CmdHelpText.cond] for more information on the requirements for
+## [param cond].
 func add_help_cond(args: String, helptxt: String, cond: Callable) -> ConsoleCommand:
 	add_help(args, helptxt)
 	help_text.back().cond = cond
 	return self
+
+
+## Add a [Callable] to determine if the command should be disabled. See [member disabled_procs] for
+## information on the requirements for [param proc].
 func add_disable(proc: Callable) -> ConsoleCommand:
 	disabled_procs.append(proc)
 	return self
+
+
+## Enable or disable debug-only status for this command.
 func debug(state := true) -> ConsoleCommand:
 	_debug = state
 	return self
 #endregion
 
+
+## Returns [code]true[/code] if the command is debug-only.
 func is_debug() -> bool:
 	return _debug
 
+
+## Get all the help text for this command.
 func get_helptext() -> String:
 	var s := ""
 	for ht in help_text:
 		if ht.cond and not ht.cond.call(): continue
-		s += "%s %s\n    %s\n" % [text,ht.args,ht.text.replace("\n","\n    ")]
+		s += "%s %s\n    %s\n" % [text, ht.args, ht.text.replace("\n","\n    ")]
 	return s
+
+
+## Output help text to the given [param console]. [param target] may optionally also be supplied to
+## specify where to output to.
+## [br][br]
+## [param target] may only be [code]null[/code] or of type [ConsoleFoldableContainer] or 
+## [Container].
 func output_helptext(console: BaseConsole, target = null) -> void:
 	var texts: Array[CmdHelpText] = []
 	for ht in help_text:
 		if ht.cond and not ht.cond.call(): continue
 		texts.append(ht)
+		
 	if not target:
 		for ht in texts:
-			console.add(BaseConsole.make_text("%s %s" % [text,ht.args], "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			console.add(BaseConsole.make_text(
+					"%s %s" % [text, ht.args],
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			var indent := BaseConsole.make_indent(HELPTEXT_INDENT)
 			console.add(indent)
-			indent.add_child(BaseConsole.make_text(ht.text, "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			indent.add_child(BaseConsole.make_text(
+					ht.text,
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			
 	elif target is ConsoleFoldableContainer:
 		for ht in texts:
-			target.add(BaseConsole.make_text("%s %s" % [text,ht.args], "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			target.add(BaseConsole.make_text(
+					"%s %s" % [text, ht.args],
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			target.add(console.make_header_spacing(0))
 			var indent := BaseConsole.make_indent(HELPTEXT_INDENT)
 			target.add(indent)
 			var vbox := VBoxContainer.new()
 			indent.add_child(vbox)
-			vbox.add_child(BaseConsole.make_text(ht.text, "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			vbox.add_child(BaseConsole.make_text(
+					ht.text,
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			vbox.add_child(console.make_header_spacing(0))
 
 	elif target is Container:
 		for ht in texts:
-			target.add_child(BaseConsole.make_text("%s %s" % [text,ht.args], "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			target.add_child(BaseConsole.make_text(
+					"%s %s" % [text, ht.args],
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			target.add_child(console.make_header_spacing(0))
 			target.add_child(BaseConsole.make_indent(HELPTEXT_INDENT))
-			target.add_child(BaseConsole.make_text(ht.text, "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			target.add_child(BaseConsole.make_text(
+					ht.text,
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			target.add_child(console.make_header_spacing(0))
 			target.add_child(BaseConsole.make_indent(-HELPTEXT_INDENT))
-func output_usage(console: BaseConsole) -> void:
-	console.add(BaseConsole.make_text("Usage:\n%s" % get_helptext(), "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 
+
+## Output usage instructions to [param console].
+func output_usage(console: BaseConsole) -> void:
+	console.add(BaseConsole.make_text(
+			"Usage:\n%s" % get_helptext(),
+			"",
+			AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+
+
+## Returns [code]true[/code] if this command is currently disabled. Returns [code]false[/code]
+## otherwise.
 func is_disabled() -> bool:
 	for proc in disabled_procs:
-		if proc.call(): return true
+		if proc.call():
+			return true
 	return false
+
 
 func _to_string():
 	var s = "COMMAND(" + text

--- a/godot_ap/ap_files/console_command.gd
+++ b/godot_ap/ap_files/console_command.gd
@@ -57,7 +57,7 @@ func set_call(caller: Callable) -> ConsoleCommand:
 
 ## Set [member autofill_proc].
 func set_autofill(caller: Variant) -> ConsoleCommand:
-	assert(caller is bool or caller is Callable)
+	assert(caller is Callable)
 	autofill_proc = caller
 	return self
 

--- a/godot_ap/ap_files/console_command.gd
+++ b/godot_ap/ap_files/console_command.gd
@@ -34,7 +34,7 @@ var call_proc: Variant = null # Callable(ConsoleCommand,String)->void | null
 ## [br][br]
 ## Should take a [String] as its first parameter and return an [Array] of [String]s. The parameter
 ## contains the current input by the user, and the returned value contains an array of possible
-## completions
+## completions.
 var autofill_proc: Variant = null # Callable(String)->Array[String] | null
 ## An [Array] of [Callable]s that determine whether or not this command is disabled. If any return
 ## [code]true[/code], this command is considered disabled.

--- a/godot_ap/ap_files/datacache.gd
+++ b/godot_ap/ap_files/datacache.gd
@@ -1,34 +1,59 @@
 class_name DataCache
+## Item and location names for a game.
 
+## A [Dictionary] mapping item names to their numerical ids.
 var item_name_to_id: Dictionary[String, int] = {}
+## A [Dictionary] mapping location names to their numerical ids.
 var location_name_to_id: Dictionary[String, int] = {}
+## Checksum for the data.
 var checksum: String = ""
 
+
+## Load data cache from a [Dictionary].
 static func from(data: Dictionary) -> DataCache:
 	var c := DataCache.new()
-	c.item_name_to_id.assign(data.get("item_name_to_id",c.item_name_to_id))
+	
+	c.item_name_to_id.assign(data.get("item_name_to_id", c.item_name_to_id))
 	for k in c.item_name_to_id.keys():
 		c.item_name_to_id[k] = c.item_name_to_id[k] as int
-	c.location_name_to_id.assign(data.get("location_name_to_id",c.location_name_to_id))
+	
+	c.location_name_to_id.assign(data.get("location_name_to_id", c.location_name_to_id))
 	for k in c.location_name_to_id.keys():
 		c.location_name_to_id[k] = c.location_name_to_id[k] as int
+		
 	c.checksum = data.get("checksum",c.checksum)
 	return c
+
+
+## Load data cache from [param file].
 static func from_file(file: FileAccess) -> DataCache:
-	if not file: return null
+	if not file:
+		return null
 	var dict = JSON.parse_string(file.get_as_text())
 	if dict is Dictionary:
 		return from(dict)
 	return null
+
+
+## Get the id for the [param name] of an item.
 func get_item_id(name: String) -> int:
 	var id: int = item_name_to_id.get(name, -1)
 	return id
+
+
+## Get the id for the [param name] of a location.
 func get_loc_id(name: String) -> int:
 	var id: int = location_name_to_id.get(name, -1)
 	return id
+
+
+## Get the name of the item with the given [param id].
 func get_item_name(id: int) -> String:
 	var v: Variant = item_name_to_id.find_key(id)
 	return str(v) if v else str(id)
+
+
+## Get the location of the item with the given [param id].
 func get_loc_name(id: int) -> String:
 	if id < 0:
 		if id == -1:
@@ -39,5 +64,7 @@ func get_loc_name(id: int) -> String:
 	var v: Variant = location_name_to_id.find_key(id)
 	return str(v) if v else str(id)
 
+
+## Check the validity of this cache.
 func is_valid() -> bool:
 	return not checksum.is_empty()

--- a/godot_ap/ap_files/datacache.gd
+++ b/godot_ap/ap_files/datacache.gd
@@ -1,9 +1,9 @@
 class_name DataCache
 ## Item and location names for a game.
 
-## A [Dictionary] mapping item names to their numerical ids.
+## A [Dictionary] mapping item names to their numerical IDs.
 var item_name_to_id: Dictionary[String, int] = {}
-## A [Dictionary] mapping location names to their numerical ids.
+## A [Dictionary] mapping location names to their numerical IDs.
 var location_name_to_id: Dictionary[String, int] = {}
 ## Checksum for the data.
 var checksum: String = ""
@@ -35,13 +35,13 @@ static func from_file(file: FileAccess) -> DataCache:
 	return null
 
 
-## Get the id for the [param name] of an item.
+## Get the ID for the [param name] of an item.
 func get_item_id(name: String) -> int:
 	var id: int = item_name_to_id.get(name, -1)
 	return id
 
 
-## Get the id for the [param name] of a location.
+## Get the ID for the [param name] of a location.
 func get_loc_id(name: String) -> int:
 	var id: int = location_name_to_id.get(name, -1)
 	return id

--- a/godot_ap/ap_files/network_hint.gd
+++ b/godot_ap/ap_files/network_hint.gd
@@ -19,7 +19,6 @@ enum Status {
 	NOT_FOUND = -1, # Compat, can probaly remove soon
 }
 
-
 ## A mapping of [enum Status] to [String]s for display purposes.
 static var status_names: Dictionary[Status, String] = {
 	Status.FOUND: "Found",
@@ -29,8 +28,6 @@ static var status_names: Dictionary[Status, String] = {
 	Status.PRIORITY: "Priority",
 	Status.NOT_FOUND: "Not Found",
 }
-
-
 ## A mapping of [enum Status] to [enum AP.RichColor] for display purposes.
 static var status_colors: Dictionary[Status, AP.RichColor] = {
 	Status.FOUND: AP.RichColor.GREEN,
@@ -40,7 +37,6 @@ static var status_colors: Dictionary[Status, AP.RichColor] = {
 	Status.PRIORITY: AP.RichColor.PLUM,
 	Status.NOT_FOUND: AP.RichColor.RED,
 }
-
 
 ## The item that has been hinted.
 var item: NetworkItem
@@ -99,4 +95,10 @@ func as_plain_string() -> String:
 	]
 
 func _to_string():
-	return "HINT(%d %d %d %d %d)" % [item.src_player_id,item.id,item.dest_player_id,item.loc_id,status]
+	return "HINT(%d %d %d %d %d)" % [
+		item.src_player_id,
+		item.id,
+		item.dest_player_id,
+		item.loc_id,
+		status
+	]

--- a/godot_ap/ap_files/network_hint.gd
+++ b/godot_ap/ap_files/network_hint.gd
@@ -1,7 +1,8 @@
 class_name NetworkHint
-## A hint for an item's location.
-
-
+## A hint for an item.
+##
+## @tutorial(Archipelago Documentation): https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#hint
+ 
 ## Priority information for the hint.
 enum Status {
 	## No priority specified
@@ -30,7 +31,7 @@ static var status_names: Dictionary[Status, String] = {
 }
 
 
-## A mapping of [enum Status] to [AP.RichColor] for display purposes.
+## A mapping of [enum Status] to [enum AP.RichColor] for display purposes.
 static var status_colors: Dictionary[Status, AP.RichColor] = {
 	Status.FOUND: AP.RichColor.GREEN,
 	Status.UNSPECIFIED: AP.RichColor.NIL,
@@ -41,13 +42,15 @@ static var status_colors: Dictionary[Status, AP.RichColor] = {
 }
 
 
-## The item that has been hinted
+## The item that has been hinted.
 var item: NetworkItem
+## The entrance the item's location is behind.
 var entrance: String
+## The priority of the hinted item.
 var status: Status = Status.NOT_FOUND
 
 
-## Deserialize a received hint field.
+## Deserialize a received hint.
 static func from(json: Dictionary) -> NetworkHint:
 	if json["class"] != "Hint":
 		return null
@@ -67,7 +70,7 @@ func is_local() -> bool:
 	return item.is_local()
 
 
-## Create a label displaying this object's [member status]
+## Create a label displaying this object's [member status].
 func make_status() -> ConsoleLabel:
 	return NetworkHint.make_hint_status(status)
 

--- a/godot_ap/ap_files/network_hint.gd
+++ b/godot_ap/ap_files/network_hint.gd
@@ -13,9 +13,9 @@ enum Status {
 	AVOID = 20,
 	## Item is important and should be prioritized
 	PRIORITY = 30,
-
 	## The location has been found.
 	FOUND = -2, # Special case, not actually a status value but used for the same GUI column
+	## Exists only for compatability, may be removed soon.
 	NOT_FOUND = -1, # Compat, can probaly remove soon
 }
 

--- a/godot_ap/ap_files/network_hint.gd
+++ b/godot_ap/ap_files/network_hint.gd
@@ -1,15 +1,25 @@
 class_name NetworkHint
+## A hint for an item's location.
 
+
+## Priority information for the hint.
 enum Status {
+	## No priority specified
 	UNSPECIFIED = 0,
+	## Item is unimportant.
 	NON_PRIORITY = 10,
+	## Item is detrimental and to be avoided
 	AVOID = 20,
+	## Item is important and should be prioritized
 	PRIORITY = 30,
 
+	## The location has been found.
 	FOUND = -2, # Special case, not actually a status value but used for the same GUI column
 	NOT_FOUND = -1, # Compat, can probaly remove soon
 }
 
+
+## A mapping of [enum Status] to [String]s for display purposes.
 static var status_names: Dictionary[Status, String] = {
 	Status.FOUND: "Found",
 	Status.UNSPECIFIED: "Unspecified",
@@ -18,6 +28,9 @@ static var status_names: Dictionary[Status, String] = {
 	Status.PRIORITY: "Priority",
 	Status.NOT_FOUND: "Not Found",
 }
+
+
+## A mapping of [enum Status] to [AP.RichColor] for display purposes.
 static var status_colors: Dictionary[Status, AP.RichColor] = {
 	Status.FOUND: AP.RichColor.GREEN,
 	Status.UNSPECIFIED: AP.RichColor.NIL,
@@ -27,10 +40,14 @@ static var status_colors: Dictionary[Status, AP.RichColor] = {
 	Status.NOT_FOUND: AP.RichColor.RED,
 }
 
+
+## The item that has been hinted
 var item: NetworkItem
 var entrance: String
 var status: Status = Status.NOT_FOUND
 
+
+## Deserialize a received hint field.
 static func from(json: Dictionary) -> NetworkHint:
 	if json["class"] != "Hint":
 		return null
@@ -43,21 +60,32 @@ static func from(json: Dictionary) -> NetworkHint:
 	hint.entrance = json.get("entrance", "")
 	return hint
 
+
+## Returns [code]true[/code] if [member item] is found in the client's world, and [code]false[/code]
+## if it's found in another player's world.
 func is_local() -> bool:
 	return item.is_local()
 
+
+## Create a label displaying this object's [member status]
 func make_status() -> ConsoleLabel:
 	return NetworkHint.make_hint_status(status)
 
+
+## Create a label displaying the given [enum Status] value.
 static func make_hint_status(targ_status: Status) -> ConsoleLabel:
 	var txt = NetworkHint.status_names.get(targ_status, "Unknown")
 	var color: AP.RichColor = NetworkHint.status_colors.get(targ_status, AP.RichColor.RED)
 	return BaseConsole.make_text(txt, "", AP.ComplexColor.as_rich(color))
 
+
+## Update label [param part] to display a different [enum Status].
 static func update_hint_status(targ_status: Status, part: ConsoleLabel):
 	part.text = NetworkHint.status_names.get(targ_status, "Unknown")
 	part.rich_color = NetworkHint.status_colors.get(targ_status, AP.RichColor.RED)
 
+
+## Create a plain text description of this hint.
 func as_plain_string() -> String:
 	return "%s %s '%s' (%s) for %s at '%s'" % [
 		Archipelago.conn.get_player_name(item.src_player_id),

--- a/godot_ap/ap_files/network_item.gd
+++ b/godot_ap/ap_files/network_item.gd
@@ -1,13 +1,29 @@
 class_name NetworkItem
+## A multiworld item.
+##
+## @tutorial(Archipelago Documentation): https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#networkitem
 
+## The item's id.
 var id: int
+## The id of this item's location.
 var loc_id: int
+## The id of the player whose world this item is in.
 var src_player_id: int
+## The id of the player who will receive this item.
 var dest_player_id: int
+## Combination of bit flags with information about the item. See [enum AP.ItemClassification] for
+## more information.
 var flags: int
 
+
+## Get a text description of this item's [member flags].
 func get_classification() -> String:
 	return AP.get_item_classification(flags)
+
+
+## Create an item from a received [Dictionary]. If [param recv] is [code]true[/code], the 
+## information is interpreted as an item found in another world. Otherwise the item is
+## assumed to be found in the client's world.
 static func from(json: Dictionary, recv: bool) -> NetworkItem:
 	if json["class"] != "NetworkItem":
 		return null
@@ -18,6 +34,9 @@ static func from(json: Dictionary, recv: bool) -> NetworkItem:
 	v.dest_player_id = Archipelago.conn.player_id if recv else json["player"]
 	v.flags = json["flags"]
 	return v
+
+
+## Create an item from a [Dictionary] describing a hint.
 static func from_hint(json: Dictionary) -> NetworkItem:
 	if json["class"] != "Hint":
 		return null
@@ -29,14 +48,28 @@ static func from_hint(json: Dictionary) -> NetworkItem:
 	v.flags = json["item_flags"]
 	return v
 
+
+## Returns [code]true[/code] if this item is found in it's player's own world. Returns
+## [code]false[/code] if it's found in another player's world.
 func is_local() -> bool:
 	return src_player_id == dest_player_id
+
+
+## Returns [code]true[/code] if the item is a progression item. Returns [code]false[/code] if it
+## isn't.
 func is_prog() -> bool:
 	return flags & AP.ItemClassification.PROG
 
+
+## Returns the name of the item.
 func get_name() -> String:
 	return Archipelago.conn.get_gamedata_for_player(dest_player_id).get_item_name(id)
+
+
 func _to_string():
 	return "ITEM(%d at %d,player %d->%d,flags %d)" % [id,loc_id,src_player_id,dest_player_id,flags]
+
+
+## Creates a label describing this item for outputting to a console.
 func output() -> ConsoleLabel:
 	return BaseConsole.make_item(id, flags, Archipelago.conn.get_gamedata_for_player(dest_player_id))

--- a/godot_ap/ap_files/network_item.gd
+++ b/godot_ap/ap_files/network_item.gd
@@ -3,13 +3,13 @@ class_name NetworkItem
 ##
 ## @tutorial(Archipelago Documentation): https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#networkitem
 
-## The item's id.
+## The item's ID.
 var id: int
-## The id of this item's location.
+## The ID of this item's location.
 var loc_id: int
-## The id of the player whose world this item is in.
+## The ID of the player whose world this item is in.
 var src_player_id: int
-## The id of the player who will receive this item.
+## The ID of the player who will receive this item.
 var dest_player_id: int
 ## Combination of bit flags with information about the item. See [enum AP.ItemClassification] for
 ## more information.
@@ -67,9 +67,16 @@ func get_name() -> String:
 
 
 func _to_string():
-	return "ITEM(%d at %d,player %d->%d,flags %d)" % [id,loc_id,src_player_id,dest_player_id,flags]
+	return "ITEM(%d at %d,player %d->%d,flags %d)" % [
+		id,
+		loc_id,
+		src_player_id,
+		dest_player_id,
+		flags
+	]
 
 
 ## Creates a label describing this item for outputting to a console.
 func output() -> ConsoleLabel:
-	return BaseConsole.make_item(id, flags, Archipelago.conn.get_gamedata_for_player(dest_player_id))
+	return BaseConsole.make_item(id, flags,
+			Archipelago.conn.get_gamedata_for_player(dest_player_id))

--- a/godot_ap/ap_files/network_item.gd
+++ b/godot_ap/ap_files/network_item.gd
@@ -21,7 +21,7 @@ func get_classification() -> String:
 	return AP.get_item_classification(flags)
 
 
-## Create an item from a received [Dictionary]. If [param recv] is [code]true[/code], the 
+## Deserialize item information. If [param recv] is [code]true[/code], the 
 ## information is interpreted as an item found in another world. Otherwise the item is
 ## assumed to be found in the client's world.
 static func from(json: Dictionary, recv: bool) -> NetworkItem:
@@ -36,7 +36,7 @@ static func from(json: Dictionary, recv: bool) -> NetworkItem:
 	return v
 
 
-## Create an item from a [Dictionary] describing a hint.
+## Deserialize item information from a [Dictionary] describing a hint.
 static func from_hint(json: Dictionary) -> NetworkItem:
 	if json["class"] != "Hint":
 		return null
@@ -61,7 +61,7 @@ func is_prog() -> bool:
 	return flags & AP.ItemClassification.PROG
 
 
-## Returns the name of the item.
+## Get the name of the item.
 func get_name() -> String:
 	return Archipelago.conn.get_gamedata_for_player(dest_player_id).get_item_name(id)
 
@@ -76,7 +76,7 @@ func _to_string():
 	]
 
 
-## Creates a label describing this item for outputting to a console.
+## Create a label describing this item for outputting to a console.
 func output() -> ConsoleLabel:
 	return BaseConsole.make_item(id, flags,
 			Archipelago.conn.get_gamedata_for_player(dest_player_id))

--- a/godot_ap/ap_files/network_player.gd
+++ b/godot_ap/ap_files/network_player.gd
@@ -29,7 +29,7 @@ func get_name(use_alias := true) -> String:
 	return ret
 
 
-## Create a player from a [Dictionary].
+## Deserialize player information from a [Dictionary].
 static func from(json: Dictionary) -> NetworkPlayer:
 	if json["class"] != "NetworkPlayer":
 		return null

--- a/godot_ap/ap_files/network_player.gd
+++ b/godot_ap/ap_files/network_player.gd
@@ -1,18 +1,35 @@
 class_name NetworkPlayer
+## A player in the multiworld.
+##
+## @tutorial(Archipelago Documentation): https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#networkplayer
 
+## The id of the team that the player is on.
 var team: int
+## The player's slot number.
 var slot: int
+## The player's alias.
 var alias := ""
+## The player's name.
 var name : String
 
+
+## Get the slot information for this player.
 func get_slot() -> NetworkSlot:
 	return Archipelago.conn.get_slot(slot)
+
+
+## Get the player's name. If [param use_alias] is true the player's alias will be returned instead,
+## if present.
 func get_name(use_alias := true) -> String:
 	var ret := ""
-	if use_alias: ret = alias
-	if not ret: ret = name
+	if use_alias:
+		ret = alias
+	if not ret:
+		ret = name
 	return ret
 
+
+## Create a player from a [Dictionary].
 static func from(json: Dictionary) -> NetworkPlayer:
 	if json["class"] != "NetworkPlayer":
 		return null
@@ -26,7 +43,11 @@ static func from(json: Dictionary) -> NetworkPlayer:
 			v.alias = ""
 	return v
 
+
 func _to_string():
 	return "PLAYER(%s[%s],team %d,slot %d)" % [name,alias,team,slot]
+
+
+## Create a label to display on a console.
 func output() -> ConsoleLabel:
 	return BaseConsole.make_player(slot)

--- a/godot_ap/ap_files/network_player.gd
+++ b/godot_ap/ap_files/network_player.gd
@@ -3,7 +3,7 @@ class_name NetworkPlayer
 ##
 ## @tutorial(Archipelago Documentation): https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#networkplayer
 
-## The id of the team that the player is on.
+## The ID of the team that the player is on.
 var team: int
 ## The player's slot number.
 var slot: int
@@ -45,7 +45,7 @@ static func from(json: Dictionary) -> NetworkPlayer:
 
 
 func _to_string():
-	return "PLAYER(%s[%s],team %d,slot %d)" % [name,alias,team,slot]
+	return "PLAYER(%s[%s],team %d,slot %d)" % [name, alias, team, slot]
 
 
 ## Create a label to display on a console.

--- a/godot_ap/ap_files/network_slot.gd
+++ b/godot_ap/ap_files/network_slot.gd
@@ -1,10 +1,20 @@
 class_name NetworkSlot
+## Information about a slot in the multiworld.
+##
+## @tutorial(Archipelago Documentation): https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#networkslot
 
+## The name of the slot.
 var name : String
+## The game played on the slot.
 var game: String
+## The type of the slot. [code]0x00[/code] if the slot is for a spectator, [code]0x01[/code] if it's
+## for a player, and [code]0x02[/code] if it's for a group.
 var type: int #spectator = 0x00, player = 0x01, group = 0x02
+## If the slot is for a group, the ids of the players in the group.
 var group_members: Array[int] = []
 
+
+## Create a slot from a [Dictionary].
 static func from(json: Dictionary) -> NetworkSlot:
 	if json["class"] != "NetworkSlot":
 		return null
@@ -14,6 +24,7 @@ static func from(json: Dictionary) -> NetworkSlot:
 	v.type = json["type"]
 	v.group_members.assign(json["group_members"])
 	return v
+
 
 func _to_string():
 	return "SLOT(%s[%s],type %d,members %s)" % [name,game,type,group_members]

--- a/godot_ap/ap_files/network_slot.gd
+++ b/godot_ap/ap_files/network_slot.gd
@@ -14,7 +14,7 @@ var type: int
 var group_members: Array[int] = []
 
 
-## Create a slot from a [Dictionary].
+## Deserialize slot information from a [Dictionary].
 static func from(json: Dictionary) -> NetworkSlot:
 	if json["class"] != "NetworkSlot":
 		return null

--- a/godot_ap/ap_files/network_slot.gd
+++ b/godot_ap/ap_files/network_slot.gd
@@ -10,7 +10,7 @@ var game: String
 ## The type of the slot. [code]0x00[/code] if the slot is for a spectator, [code]0x01[/code] if it's
 ## for a player, and [code]0x02[/code] if it's for a group.
 var type: int #spectator = 0x00, player = 0x01, group = 0x02
-## If the slot is for a group, the ids of the players in the group.
+## If the slot is for a group, the IDs of the players in the group.
 var group_members: Array[int] = []
 
 
@@ -27,4 +27,4 @@ static func from(json: Dictionary) -> NetworkSlot:
 
 
 func _to_string():
-	return "SLOT(%s[%s],type %d,members %s)" % [name,game,type,group_members]
+	return "SLOT(%s[%s],type %d,members %s)" % [name, game, type, group_members]

--- a/godot_ap/ap_files/network_slot.gd
+++ b/godot_ap/ap_files/network_slot.gd
@@ -9,7 +9,7 @@ var name : String
 var game: String
 ## The type of the slot. [code]0x00[/code] if the slot is for a spectator, [code]0x01[/code] if it's
 ## for a player, and [code]0x02[/code] if it's for a group.
-var type: int #spectator = 0x00, player = 0x01, group = 0x02
+var type: int
 ## If the slot is for a group, the IDs of the players in the group.
 var group_members: Array[int] = []
 

--- a/godot_ap/ap_files/version.gd
+++ b/godot_ap/ap_files/version.gd
@@ -1,9 +1,18 @@
-class_name Version extends Resource
+class_name Version 
+extends Resource
+## Software version description.
+##
+## @tutorial(Semantic Versioning): https://semver.org/
 
+## The major version.
 @export var major := 0
+## The minor version.
 @export var minor := 0
+## The build number.
 @export var build := 0
 
+
+## Create a version object from a [Dictionary].
 static func from(json: Dictionary) -> Version:
 	if json["class"] != "Version":
 		return null
@@ -12,6 +21,9 @@ static func from(json: Dictionary) -> Version:
 	v.minor = json["minor"]
 	v.build = json["build"]
 	return v
+
+
+## Create a version object from provided [int]s.
 static func val(v1:int, v2:int, v3:int) -> Version:
 	var v := Version.new()
 	v.major = v1
@@ -19,9 +31,14 @@ static func val(v1:int, v2:int, v3:int) -> Version:
 	v.build = v3
 	return v
 
+
 func _to_string():
 	return "VER(%d.%d.%d)" % [major,minor,build]
 
+
+## Compare two version numbers. Returns a value less than [code]0[/code] if [param other] is
+## a newer version, and a value greater than [code]0[/code] if [param other] is older. Returns
+## [code]0[/code] if both versions are identical.
 func compare(other: Version) -> int:
 	if major != other.major:
 		return major - other.major
@@ -29,8 +46,10 @@ func compare(other: Version) -> int:
 		return minor - other.minor
 	return build - other.build
 
+
 func _as_ap_dict() -> Dictionary:
 	return {"major":major,"minor":minor,"build":build,"class":"Version"}
+
 
 func _as_semver_dict() -> Dictionary:
 	return {"major":major,"minor":minor,"patch":build}

--- a/godot_ap/ap_files/version.gd
+++ b/godot_ap/ap_files/version.gd
@@ -33,7 +33,7 @@ static func val(v1:int, v2:int, v3:int) -> Version:
 
 
 func _to_string():
-	return "VER(%d.%d.%d)" % [major,minor,build]
+	return "VER(%d.%d.%d)" % [major, minor, build]
 
 
 ## Compare two version numbers. Returns a value less than [code]0[/code] if [param other] is
@@ -48,8 +48,8 @@ func compare(other: Version) -> int:
 
 
 func _as_ap_dict() -> Dictionary:
-	return {"major":major,"minor":minor,"build":build,"class":"Version"}
+	return { "major": major, "minor": minor, "build": build, "class": "Version" }
 
 
 func _as_semver_dict() -> Dictionary:
-	return {"major":major,"minor":minor,"patch":build}
+	return { "major": major, "minor": minor, "patch": build }

--- a/godot_ap/ap_files/version.gd
+++ b/godot_ap/ap_files/version.gd
@@ -12,7 +12,7 @@ extends Resource
 @export var build := 0
 
 
-## Create a version object from a [Dictionary].
+## Deserialize a version object from a [Dictionary].
 static func from(json: Dictionary) -> Version:
 	if json["class"] != "Version":
 		return null

--- a/godot_ap/autoloads/archipelago.gd
+++ b/godot_ap/autoloads/archipelago.gd
@@ -211,7 +211,8 @@ static func is_rich_color_name(s: String) -> bool:
 	return RichColor.keys().map(func(c): return str(c).to_lower()).has(s)
 
 
-## Gets a [enum RichColor] from [param s]. [code]NIL[/code] is returned if the string is invalid.
+## Gets a [enum RichColor] from [param s]. [member AP.ComplexColor.NIL] is returned if the string is
+## invalid.
 static func rich_color_from_name(s: String) -> RichColor:
 	var ind: int = RichColor.keys().map(func(c): return str(c).to_lower()).find(s)
 	if ind > -1:
@@ -297,10 +298,9 @@ var _socket: WebSocketPeer
 ## [code]godot_ap/autoloads/archipelago.tscn[/code].
 var config : APConfigManager
 ## A save manager, designed to handle local save files tied to a specific room/slot.
-## Null unless a node inheriting from [APSaveManager] is added to to 
-## [code]godot_ap/autoloads/archipelago.tscn[/code].
 ## [br][br]
-## Can be [code]null[/code] if not provided in [code]godot_ap/autoloads/archipelago.tscn[/code].
+## Is [code]null[/code] unless a node inheriting from [APSaveManager] is added to
+## [code]godot_ap/autoloads/archipelago.tscn[/code].
 var save_manager : APSaveManager
 
 #region CONNECTION

--- a/godot_ap/autoloads/archipelago.gd
+++ b/godot_ap/autoloads/archipelago.gd
@@ -17,17 +17,15 @@ extends Node
 ## The version of your client. Arbitrary number for you to manage.
 @export var AP_CLIENT_VERSION := Version.val(0,0,0)
 
-## The target AP version. Not arbitrary - used in `Connect` packet.
+## The target AP version. Not arbitrary - used in [code]Connect[/code] packet.
 @export var AP_VERSION := Version.val(0,5,0)
 
 ## The [enum ItemHandling] to use when connecting.
 @export var AP_ITEM_HANDLING := ItemHandling.ALL
 
-
 @export_group("Extra Options")
 ## Aliases for Traps in TrapLink. When the key is received, the value will be used instead.
 @export var TRAP_LINK_ALIASES: Dictionary[String, String]
-
 
 @export_group("Client Settings")
 ## Prints what items have been previously collected when reconnecting to a slot.
@@ -39,17 +37,15 @@ extends Node
 ## Automatically opens a default AP text console.
 @export var AP_AUTO_OPEN_CONSOLE := false
 
-## Show items that are both progression and useful with their own color
+## Show items that are both progression and useful with their own color.
 @export var AP_ENABLE_PROGUSEFUL := false
 
-
 @export_subgroup("UI")
-## Automatically open the Connection box when the console opens
+## Automatically open the Connection box when the console opens.
 @export var AP_CONSOLE_CONNECTION_OPEN := false
 
-## Automatically open/close the Connection box based on connected status
+## Automatically open/close the Connection box based on connected status.
 @export var AP_CONSOLE_CONNECTION_AUTO := true
-
 
 @export_subgroup("Logging")
 ## Enables additional logging.
@@ -70,56 +66,53 @@ extends Node
 	"checksum",
 ]
 
-
 @export_group("Misc")
 ## Size, in MB, of the websocket inbound buffer.
 ## Raising may help if large datapackages are causing disconnections.
 @export_range(5, 500, 1, "or_greater", "hide_slider") var websocket_inbuffer_mb: int = 50
 
-
 @export_group("")
 
-
+## Timer for detecting when the connection hangs. If a disconnect is requested and the connection
+## remains open for longer than the timer, the connection is forcibly closed.
 @onready var hang_clock: Timer = $HangTimer
-
 
 #region Connection packets
 # See `ConnectionInfo` (Archipelago.conn) for more signals
-## Emitted before connection is attempted
+## Emitted before connection is attempted.
 signal preconnect
 
-## Emitted when [code]RoomInfo[/code] is received
+## Emitted when [code]RoomInfo[/code] is received.
 signal roominfo(conn: ConnectionInfo, json: Dictionary)
 
-## Emitted when [code]ConnectionRefused[/code] is received
+## Emitted when [code]ConnectionRefused[/code] is received.
 signal connectionrefused(conn: ConnectionInfo, json: Dictionary)
 
-## Emitted when [code]Connected[/code] is received
+## Emitted when [code]Connected[/code] is received.
 signal connected(conn: ConnectionInfo, json: Dictionary)
 
-## Emitted when [code]PrintJSON[/code] is received
+## Emitted when [code]PrintJSON[/code] is received.
 signal printjson(json: Dictionary, plaintext: String)
 
-## Emitted when the connection is lost
+## Emitted when the connection is lost.
 signal disconnected
 #endregion
 
-
 #region Other signals
-## Signals when [member AP.status] changes
+## Signals when [member AP.status] changes.
 signal status_updated
 
-## Signals when all required datapacks have finished loading
+## Signals when all required datapacks have finished loading.
 signal all_datapacks_loaded
 
 ## Emitted when a location should be cleared/deleted from the world,
-## as it has been "already collected"
+## as it has already been collected.
 signal remove_location(loc_id: int)
 
-## Emitted when [member AP.AP_GAME_TAGS] is updated
+## Emitted when [member AP.AP_GAME_TAGS] is updated.
 signal on_tag_change
 
-## Emitted when an output console is attached
+## Emitted when an output console is attached.
 signal on_attach_console
 
 # Debug purposes
@@ -127,11 +120,10 @@ signal on_attach_console
 signal _logged_message(msg: String)
 #endregion
 
-
 #region COLORS
 ## Represents a color in one of multiple formats.
 class ComplexColor:
-	## The [RichColor] or [code]null[/code]
+	## The [enum AP.RichColor] or [code]null[/code].
 	var rich :
 		set(val):
 			if val is RichColor:
@@ -141,7 +133,7 @@ class ComplexColor:
 			else: rich = null
 	
 	
-	## The [SpecialColor] or [code]null[/code]
+	## The [enum AP.SpecialColor] or [code]null[/code].
 	var special :
 		set(val):
 			if val is SpecialColor:
@@ -152,7 +144,7 @@ class ComplexColor:
 				special = null
 	
 	
-	## A [String] or [Color] plain value, or [code]null[/code]
+	## A [String] or [Color] plain value, or [code]null[/code].
 	var plain :
 		set(val):
 			if val is String:
@@ -164,65 +156,62 @@ class ComplexColor:
 			else: plain = null
 	
 	
-	## Construct a [ComplexColor] representing a [RichColor] value
+	## Construct a complex color representing a [enum AP.RichColor] value.
 	static func as_rich(color: RichColor) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.rich = color
 		return ret
 
 
-	## Construct a [ComplexColor] representing a [SpecialColor] value
+	## Construct a complex color representing a [enum AP.SpecialColor] value.
 	static func as_special(color: SpecialColor) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.special = color
 		return ret
 
 
-	## Construct a [ComplexColor] representing a [String] value
+	## Construct a complex color representing a [String] value.
 	static func as_plain_str(color: String) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.plain = color
 		return ret
 
 
-	## Construct a [ComplexColor] representing a [Color] value
+	## Construct a complex color representing a [Color] value.
 	static func as_plain_col(color: Color) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.plain = color
 		return ret
 
 
-	## Get the color represented by this [ComplexColor] for a given [param node].
-	## The node is needed, as the representation can depend on the node's [Theme].
+	## Get the color represented by this complex color for the proviced [param node].
+	## [param node] is needed, as the representation can depend on the node's [Theme].
 	func calculate(node: Control) -> Color:
 		if rich: return AP.get_rich_color(node, rich)
 		if special: return AP.get_special_color(node, special)
 		return AP.color_from_name(node, plain)
 		
 		
-	## a default value
+	## A default value.
 	static var NIL := as_rich(AP.RichColor.NIL)
 
-
 ## Constants representing colors used by the AP console (as color names)
-## Used with [ComplexColor] or [method AP.get_rich_color]
+## Used with [AP.ComplexColor] or [method AP.get_rich_color].
 enum RichColor {
 	NIL, RED, GREEN, YELLOW, BLUE,
 	MAGENTA, CYAN, WHITE, BLACK, SLATEBLUE,
 	PLUM, SALMON, ORANGE, GOLD,
 }
 
-
 ## Constants representing colors used by the AP console (as use purposes)
-## Each of these translates to a [RichColor] via the [member AP.special_colors] dictionary.
-## Used with [ComplexColor] or [method AP.get_special_color]
+## Each of these translates to a [enum RichColor] via the [member AP.special_colors] dictionary.
+## Used with [AP.ComplexColor] or [method AP.get_special_color].
 enum SpecialColor {
 	ANY_PLAYER, OWN_PLAYER, ITEM_PROG, ITEM, ITEM_USEFUL, ITEM_TRAP, ITEM_PROGUSEFUL,
 	LOCATION, UI_MESSAGE, DEBUG,
 }
 
-
-## Mapping of [SpecialColor] values to [RichColor] values.
+## Mapping of [enum SpecialColor] values to [enum RichColor] values.
 static var special_colors: Dictionary[SpecialColor, RichColor] = {
 	SpecialColor.ANY_PLAYER: RichColor.YELLOW,
 	SpecialColor.OWN_PLAYER: RichColor.MAGENTA,
@@ -237,46 +226,47 @@ static var special_colors: Dictionary[SpecialColor, RichColor] = {
 }
 
 
-## Checks if [param s] matches a [RichColor].
+## Checks if [param s] matches a [enum RichColor].
 static func is_rich_color_name(s: String) -> bool:
 	if s == "nil": return false
 	return RichColor.keys().map(func(c): return str(c).to_lower()).has(s)
 
 
-## Gets a [RichColor] from [param s]. [member RichColor.NIL] is returned if the string is invalid.
+## Gets a [enum RichColor] from [param s]. [code]NIL[/code] is returned if the string is invalid.
 static func rich_color_from_name(s: String) -> RichColor:
 	var ind: int = RichColor.keys().map(func(c): return str(c).to_lower()).find(s)
 	if ind > -1: return RichColor.values()[ind]
 	return RichColor.NIL
 
 
-## Gets a [Color] from the provided [paran node]'s theme, and returns [param default] if none 
-## exists.
+# Gets a [Color] from the provided [paran node]'s theme, and returns [param default] if none 
+# exists.
 static func _get_rich_color_name(node: Control, s: String, default := Color.WHITE) -> Color:
 	if node.has_theme_color("rich_%s" % s, "Console_Label"):
 		return node.get_theme_color("rich_%s" % s, "Console_Label")
 	return default
 
 
-## Gets a [Color] represented by a [RichColor]. Uses the [Theme] of the specified [param node].
+## Gets a [Color] represented by a [enum RichColor]. Uses the [Theme] of the specified [param node].
 static func get_rich_color(node: Control, c: RichColor, default := Color.WHITE) -> Color:
 	if c == RichColor.NIL:
 		return default
 	return _get_rich_color_name(node, RichColor.find_key(c).to_lower(), default)
 
 
-## Gets a [Color] represented by a [SpecialColor]. Uses the [Theme] of the specified [param node].
+## Gets a [Color] represented by a [enum SpecialColor]. Uses the [Theme] of the specified 
+## [param node].
 static func get_special_color(node: Control, c: SpecialColor, default := Color.WHITE) -> Color:
 	return get_rich_color(node, special_colors.get(c, RichColor.NIL), default)
 
 
-## Returns the [RichColor] that the specified [SpecialColor] represents.
+## Returns the [enum RichColor] that the specified [enum SpecialColor] represents.
 static func special_to_rich_color(c: SpecialColor, default := RichColor.NIL) -> RichColor:
 	return special_colors.get(c, default)
 
 
-## Gets a [Color] from a [String]. Will use a [RichColor] if one matches, else falls back to Godot's
-## [method Color.from_string] implementation.
+## Gets a [Color] from a [String]. Will use a [enum RichColor] if one matches, else falls back to 
+## Godot's [method Color.from_string] implementation.
 static func color_from_name(node: Control, colname: String, def := Color.TRANSPARENT) -> Color:
 	return _get_rich_color_name(node, colname, Color.from_string(colname, def))
 #endregion COLORS
@@ -296,83 +286,73 @@ enum ItemHandling {
 	ALL = 7, 
 }
 
-
 ## Timestamp of the last sent DeathLink packet. Automatically updated by 
 ## [method ConnectionInfo.send_deathlink]
 var last_sent_deathlink_time: float
-
 
 ## Timestamp of the last sent TrapLink packet. Automatically updated by 
 ## [method ConnectionInfo.send_traplink]
 var last_sent_traplink_time: float
 
-
 ## The group that is used for DeathLink for this connection
 var deathlink_group: String : set = set_deathlink_group, get = get_deathlink_group
 
-
-## The current connection credentials to be used
+## The current connection credentials to be used.
 var creds: APCredentials = APCredentials.new()
 
-
-## The current [APLock] object. A default lock object is [code]unlocked[/code].
-## If an [code]unlocked[/code] object is set here, it will be [code]locked[/code] when you connect
+## The current APLock object. Saving an APLock object in a save file allows you to lock it to a 
+## particular room.
+## [br][br]
+## A default lock object is unlocked.
+## If an unlocked object is set here, it will be locked when you connect
 ## to a slot.
-## If a [code]locked[/code] object is set here, it will disallow you from connecting to any slot
+## If a locked object is set here, it will disallow you from connecting to any slot
 ## different from the one it locked to.
-## Saving an [APLock] object in a save file allows you to lock it to a particular room.
-## [code]save_manager[/code] can handle the lock for you, along with handling local save files.
+## [br][br]
+## [member save_manager] can handle the lock for you, along with handling local save files.
 var aplock: APLock = null
-
 
 ## The websocket connection to the server.
 var _socket: WebSocketPeer
 
-
 ## A config manager, designed to handle configs not tied to a specific save file.
 ## Will always exist, as GodotAP's own configs are managed by this.
 ## Can be customized by adding a node inheriting from [APConfigManager] to 
-## [code]godot_ap/autoloads/archipelago.tscn[/code]
+## [code]godot_ap/autoloads/archipelago.tscn[/code].
 var config : APConfigManager
-
 
 ## A save manager, designed to handle local save files tied to a specific room/slot.
 ## Null unless a node inheriting from [APSaveManager] is added to to 
 ## [code]godot_ap/autoloads/archipelago.tscn[/code].
-## [br]
-## Can be [code]null[/code] if not provided in [code]godot_ap/autoloads/archipelago.tscn[/code]
+## [br][br]
+## Can be [code]null[/code] if not provided in [code]godot_ap/autoloads/archipelago.tscn[/code].
 var save_manager : APSaveManager
 
-
 #region CONNECTION
-## The active Archipelago connection
+## The active Archipelago connection.
 var conn: ConnectionInfo 
-
 
 ## Emits strings representing stages of the connection process.
 ## Useful for displaying connection progress to users.
 signal connect_step(message: String)
 
-
 ## The possible connection status states.
 enum APStatus {
-	## Not connected to any Archipelago server
+	## Not connected to any Archipelago server.
 	DISCONNECTED,
-	## Socket attempting to connect
+	## Socket attempting to connect.
 	SOCKET_CONNECTING, 
-	## Socket connected, trying to connect with server
+	## Socket connected, trying to connect with server.
 	CONNECTING, 
-	## Connected with server, authenticating for selected slot
+	## Connected with server, authenticating for selected slot.
 	CONNECTED, 
-	## Authenticated and acively playing
+	## Authenticated and acively playing.
 	PLAYING, 
-	## Attempting to disconnect from the server
+	## Attempting to disconnect from the server.
 	DISCONNECTING, 
 }
 
-
 var _queue_reconnect := false
-
 
 ## The current connection status.
 var status: APStatus = APStatus.DISCONNECTED :
@@ -387,12 +367,12 @@ var status: APStatus = APStatus.DISCONNECTED :
 				ap_reconnect()
 
 
-## Returns [code]true[/code] if there is an active Archipelago connection
+## Returns [code]true[/code] if there is an active Archipelago connection.
 func is_ap_connected() -> bool:
 	return status == APStatus.PLAYING
 
 
-## Returns [code]true[/code] if there is no active Archipelago connection
+## Returns [code]true[/code] if there is no active Archipelago connection.
 func is_not_connected() -> bool:
 	return status != APStatus.PLAYING
 
@@ -400,21 +380,19 @@ func is_not_connected() -> bool:
 # Label in the [member AP.output_console] displaying the messages from [signal connect_step]
 var _connecting_part: Label 
 
-
 # Connection attempt counter
 var _connect_attempts := 1
-
 
 # If current connection attempt is using secure sockets. Alternates each attempt.
 var _wss := true 
 
 
-## Returns the URL currently being targetted for connection
+## Returns the URL currently being targeted for connection.
 func get_url() -> String:
 	return "%s://%s:%s" % ["wss" if _wss else "ws",creds.ip,creds.port]
 
 
-## Reconnect to Archipelago with the same information as before
+## Reconnect to an Archipelago room using the same information as before.
 func ap_reconnect() -> void:
 	if status != APStatus.DISCONNECTED:
 		ap_disconnect()
@@ -427,7 +405,7 @@ func ap_reconnect() -> void:
 	preconnect.emit()
 
 
-## Connect to Archipelago with the specified connection information
+## Connect to an Archipelago room with the specified connection information.
 func ap_connect(room_ip: String, room_port: String, slot_name: String, room_pwd := "") -> void:
 	if status != APStatus.DISCONNECTED:
 		ap_disconnect() # Do it here so the ip/port/slot are correct in the disconnect message
@@ -436,7 +414,7 @@ func ap_connect(room_ip: String, room_port: String, slot_name: String, room_pwd 
 	ap_reconnect()
 
 
-## Disconnect from Archipelago
+## Disconnect from the Archipelago room.
 func ap_disconnect() -> void:
 	if _connecting_part:
 		_connecting_part = null
@@ -489,13 +467,13 @@ func _create_socket() -> void:
 static var logging_file: FileAccess = null
 
 
-## Opens the GodotAP logging file, if it isn't already open
+## Opens the GodotAP logging file, if it isn't already open.
 static func open_logger() -> void:
 	if not logging_file:
 		logging_file = FileAccess.open("user://ap/ap_log.log",FileAccess.WRITE)
 
 
-## Closes the GodotAP logging file, if its open
+## Closes the GodotAP logging file, if its open.
 static func close_logger() -> void:
 	if logging_file:
 		logging_file.close()
@@ -514,42 +492,42 @@ static func _log(s: String) -> void:
 		Archipelago._logged_message.emit(msg)
 
 
-## Logs a message to the GodotAP log
+## Logs a message to the GodotAP log.
 static func log(s: Variant) -> void:
 	_log(str(s))
 
 
-## Logs a warning to the GodotAP log and Godot warning console
+## Logs a warning to the GodotAP log and Godot warning console.
 static func warn(s: Variant) -> void:
 	AP.log("[WARN] %s" % str(s))
 	push_warning(s)
 
 
-## Logs an error to the GodotAP log and Godot error console
+## Logs an error to the GodotAP log and Godot error console.
 static func error(s: Variant) -> void:
 	AP.log("[ERROR] %s" % str(s))
 	push_error(s)
 
 
-## Logs a message to the GodotAP log, but only if AP_LOG_COMMUNICATION is true
+## Logs a message to the GodotAP log, but only if [member AP_LOG_COMMUNICATION] is true.
 func comm_log(pref: String, s: Variant) -> void:
 	if not AP_LOG_COMMUNICATION: return
 	AP.log("[%s] %s" % [pref,str(s)])
 
 
-## Logs a message to the GodotAP log, but only in a Debug build
+## Logs a message to the GodotAP log, but only in a Debug build.
 static func dblog(s: Variant) -> void:
 	if not OS.is_debug_build(): return
 	AP.log(s)
 
 
-## Logs a warning to the GodotAP log and Godot warning console, but only in a Debug build
+## Logs a warning to the GodotAP log and Godot warning console, but only in a Debug build.
 static func dbwarn(s: Variant) -> void:
 	if not OS.is_debug_build(): return
 	AP.warn(s)
 
 
-## Logs an error to the GodotAP log and Godot error console, but only in a Debug build
+## Logs an error to the GodotAP log and Godot error console, but only in a Debug build.
 static func dberror(s: Variant) -> void:
 	if not OS.is_debug_build(): return
 	AP.error(s)
@@ -648,7 +626,7 @@ func send_command(cmdname: String, args: Dictionary) -> void:
 	send_packet([args])
 
 
-## Sends an array of dictionaries as a packet of commands to the server
+## Sends an array of dictionaries as a packet of commands to the server.
 func send_packet(obj: Array) -> void:
 	var s := JSON.stringify(obj)
 	Archipelago.comm_log("SEND", s)
@@ -842,13 +820,12 @@ func _handle_command(json: Dictionary) -> void:
 # Local cache of DataPackages used when connecting
 var _datapack_cache: Dictionary 
 
-
 # List of DataPackages that are still being waited for
 var _datapack_pending: Array[String] = [] 
 
 
 ## For each game (key) in the [param checksums] dictionary, requests an update for its datapackage
-## if the locally stored checksum does not match the given value
+## if the locally stored checksum does not match the given value.
 func handle_datapackage_checksums(checksums: Dictionary) -> void:
 	DirAccess.make_dir_recursive_absolute("user://ap/datapacks/") # Ensure the directory exists, for later
 	var cachefile: FileAccess = FileAccess.open("user://ap/datapacks/cache.dat", FileAccess.READ)
@@ -870,7 +847,7 @@ func handle_datapackage_checksums(checksums: Dictionary) -> void:
 		_datapack_pending.append(game)
 
 
-# Caches and stores to disk `data` as the DataCache file for `game`
+# Caches and stores to disk [param data] as the [DataCache] file for [param game]
 func _handle_datapack(game: String, data: Dictionary) -> void:
 	var data_file := FileAccess.open(
 			"user://ap/datapacks/%s.json" % game.validate_filename(),
@@ -913,11 +890,13 @@ static var _data_caches: Dictionary[String, DataCache] = {}
 
 
 ## Returns a [DataCache] for the specified game.
-## If one cann't be found, returns an empty (invalid) [DataCache], which can still be used, but will
+## If one can't be found, returns an empty (invalid) [DataCache], which can still be used, but will
 ## not have the desired data within.
 static func get_datacache(game: String) -> DataCache:
 	var ret: DataCache = _data_caches.get(game)
-	if ret: return ret
+	if ret:
+		return ret
+	
 	var data_file := FileAccess.open("user://ap/datapacks/%s.json" % game.validate_filename(), FileAccess.READ)
 	if not data_file:
 		return DataCache.new()
@@ -1048,7 +1027,7 @@ func location_checked(loc_id: int, def := false) -> bool:
 	return conn.slot_locations.get(loc_id, def)
 
 
-## Returns a list of all location ids
+## Returns a list of all location ids.
 func location_list() -> Array[int]:
 	var arr: Array[int] = []
 	arr.assign(conn.slot_locations.keys())
@@ -1085,7 +1064,7 @@ func _notification(what):
 
 
 #region CONSOLE
-## Container for the current output console
+## Container for the current output console.
 var output_console_container: ConsoleContainer = null 
 
 
@@ -1133,13 +1112,13 @@ func load_console(console_scene: Node, as_child := true) -> bool:
 	return true
 
 
-## Opens a default Archipelago text console popup
+## Opens a default Archipelago text console popup.
 func open_console() -> void:
 	if output_console: return
 	load_console(load("res://godot_ap/ui/ap_console_window.tscn").instantiate())
 
 
-## Closes the currently attached console
+## Closes the currently attached console.
 func close_console() -> void:
 	if output_console:
 		output_console.close()
@@ -1151,7 +1130,7 @@ func close_console() -> void:
 var cmd_manager: CommandManager = CommandManager.new()
 
 
-## Resets the [CommandManager] used by the archipelago console
+## Resets the [CommandManager] used by the archipelago console.
 func init_command_manager(can_connect: bool, server_autofills: bool = true):
 	cmd_manager.reset()
 	cmd_manager.register_default(func(mgr: CommandManager, msg: String):
@@ -1497,20 +1476,20 @@ func _ready():
 	# 'save_manager' can be null
 
 
-## Item Classification bits
+## Item Classification bits.
 enum ItemClassification {
-	## Filler item
+	## Filler item.
 	FILLER = 0b000,
-	## Progression item
+	## Progression item.
 	PROG = 0b001,
-	## Useful item
+	## Useful item.
 	USEFUL = 0b010,
-	## Trap item
+	## Trap item.
 	TRAP = 0b100
 }
 
 
-## Converts a set of [ItemClassification] flags to a [SpecialColor]
+## Converts a set of [enum ItemClassification] flags to a [enum SpecialColor].
 static func get_item_class_color(flags: int) -> SpecialColor:
 	if flags & ItemClassification.PROG:
 		if Archipelago.AP_ENABLE_PROGUSEFUL and (flags & ItemClassification.USEFUL):
@@ -1524,7 +1503,7 @@ static func get_item_class_color(flags: int) -> SpecialColor:
 	return SpecialColor.ITEM
 
 
-## Returns the string name representing the combined [ItemClassification] flags
+## Returns the string name representing the combined [enum ItemClassification] flags.
 static func get_item_classification(flags: int) -> String:
 	match flags:
 		ItemClassification.PROG:
@@ -1616,7 +1595,7 @@ func _update_tags() -> void:
 	on_tag_change.emit()
 
 
-## Sets a given Archipelago tag (on or off)
+## Sets a given Archipelago tag (on or off).
 func set_tag(tag: String, state := true) -> void:
 	if tag.is_empty(): return
 	for q in AP_GAME_TAGS.size():
@@ -1631,20 +1610,20 @@ func set_tag(tag: String, state := true) -> void:
 		_update_tags()
 
 
-## Checks if a given tag is active
+## Checks if a given tag is active.
 func has_tag(tag: String) -> bool:
 	return tag in AP_GAME_TAGS
 
 
-## Sets the Archipelago connection tags (overwriting all existing tags)
+## Sets the Archipelago connection tags (overwriting all existing tags).
 func set_tags(tags: Array[String]) -> void:
 	if AP_GAME_TAGS != tags:
 		AP_GAME_TAGS.assign(tags)
 		_update_tags()
 
 
-## Sets the Archipelago connection tags 
-## (overwrites tags except supported tags [code]DeathLink[/code] / [code]TrapLink[/code])
+## Sets the Archipelago connection tags.
+## Overwrites tags except supported tags [code]DeathLink[/code] / [code]TrapLink[/code].
 func set_misc_tags(tags: Array[String]) -> void:
 	var supported_tags: Array[String] = [get_deathlink_tag(), "TrapLink"]
 	tags = tags.duplicate()
@@ -1663,8 +1642,8 @@ func _ensure_connected(console: BaseConsole) -> bool:
 	return false
 
 
-## Changes this connection's DeathLink group
-## Will only send/receive deaths with other clients in the same group
+## Changes this connection's DeathLink group.
+## Will only send/receive deaths with other clients in the same group.
 func set_deathlink_group(group: String) -> void:
 	if group == deathlink_group: return
 	var deathlink := is_deathlink()
@@ -1675,38 +1654,38 @@ func set_deathlink_group(group: String) -> void:
 		set_deathlink(true)
 
 
-## Returns the current DeathLink group name
-## Will only send/receive deaths with other clients in the same group
+## Returns the current DeathLink group name.
+## Will only send/receive deaths with other clients in the same group.
 func get_deathlink_group() -> String:
 	return deathlink_group
 
 
-## Returns the tag being used for DeathLink (including DeathLink group support)
+## Returns the tag being used for DeathLink (including DeathLink group support).
 func get_deathlink_tag() -> String:
 	return "DeathLink" + deathlink_group
 
 
-## Turn DeathLink on or off
+## Turn DeathLink on or off.
 func set_deathlink(state: bool) -> void:
 	set_tag(get_deathlink_tag(), state)
 
 
-## Check if DeathLink is on
+## Check if DeathLink is on.
 func is_deathlink() -> bool:
 	return has_tag(get_deathlink_tag())
 
 
-## Turn TrapLink on or off
+## Turn TrapLink on or off.
 func set_traplink(state: bool) -> void:
 	set_tag("TrapLink", state)
 
 
-## Check if TrapLink is on
+## Check if TrapLink is on.
 func is_traplink() -> bool:
 	return has_tag("TrapLink")
 
 
-## Archipelago client statuses
+## Archipelago client statuses.
 enum ClientStatus {
 	## Error value.
 	CLIENT_UNKNOWN = 0, 
@@ -1714,15 +1693,15 @@ enum ClientStatus {
 	CLIENT_CONNECTED = 5,
 	## This slot has indicated it is ready.
 	CLIENT_READY = 10,
-	## This slot has begun playing
+	## This slot has begun playing.
 	CLIENT_PLAYING = 20, 
-	## This slot has won
+	## This slot has won.
 	CLIENT_GOAL = 30, 
 }
 
 
 ## Set the current Archipelago status.
-## Set to [code CLIENT_GOAL] when the player has won.
+## Set to [code]CLIENT_GOAL[/code] when the player has won.
 func set_client_status(stat: ClientStatus) -> void:
 	send_command("StatusUpdate", {"status": stat})
 

--- a/godot_ap/autoloads/archipelago.gd
+++ b/godot_ap/autoloads/archipelago.gd
@@ -312,7 +312,7 @@ var creds: APCredentials = APCredentials.new()
 ## [member save_manager] can handle the lock for you, along with handling local save files.
 var aplock: APLock = null
 
-## The websocket connection to the server.
+# The websocket connection to the server.
 var _socket: WebSocketPeer
 
 ## A config manager, designed to handle configs not tied to a specific save file.

--- a/godot_ap/autoloads/archipelago.gd
+++ b/godot_ap/autoloads/archipelago.gd
@@ -10,16 +10,12 @@ extends Node
 ## The game name to connect to. Empty string for [code]TextOnly[/code] / [code]Tracker[/code] /
 ## [code]HintGame[/code] clients.
 @export var AP_GAME_NAME := ""
-
 ## The tags for your game.
 @export var AP_GAME_TAGS: Array[String] = []
-
 ## The version of your client. Arbitrary number for you to manage.
 @export var AP_CLIENT_VERSION := Version.val(0,0,0)
-
 ## The target AP version. Not arbitrary - used in [code]Connect[/code] packet.
 @export var AP_VERSION := Version.val(0,5,0)
-
 ## The [enum ItemHandling] to use when connecting.
 @export var AP_ITEM_HANDLING := ItemHandling.ALL
 
@@ -30,35 +26,28 @@ extends Node
 @export_group("Client Settings")
 ## Prints what items have been previously collected when reconnecting to a slot.
 @export var AP_PRINT_ITEMS_ON_CONNECT := false
-
 ## Hide item send messages that don't involve the client.
 @export var AP_HIDE_NONLOCAL_ITEMSENDS := true
-
 ## Automatically opens a default AP text console.
 @export var AP_AUTO_OPEN_CONSOLE := false
-
 ## Show items that are both progression and useful with their own color.
 @export var AP_ENABLE_PROGUSEFUL := false
 
 @export_subgroup("UI")
 ## Automatically open the Connection box when the console opens.
 @export var AP_CONSOLE_CONNECTION_OPEN := false
-
 ## Automatically open/close the Connection box based on connected status.
 @export var AP_CONSOLE_CONNECTION_AUTO := true
 
 @export_subgroup("Logging")
 ## Enables additional logging.
 @export var AP_LOG_COMMUNICATION := false
-
 ## Enables additional logging.
 @export var AP_LOG_RECIEVED := false
-
 
 @export_subgroup("Data Packs")
 ## If true, datapackage local files will be stringified in a readable mode.
 @export var READABLE_DATAPACK_FILES := true
-
 ## Which fields should be saved from received DataPacks.
 @export var datapack_cached_fields: Array[String] = [
 	"item_name_to_id",
@@ -81,19 +70,14 @@ extends Node
 # See `ConnectionInfo` (Archipelago.conn) for more signals
 ## Emitted before connection is attempted.
 signal preconnect
-
 ## Emitted when [code]RoomInfo[/code] is received.
 signal roominfo(conn: ConnectionInfo, json: Dictionary)
-
 ## Emitted when [code]ConnectionRefused[/code] is received.
 signal connectionrefused(conn: ConnectionInfo, json: Dictionary)
-
 ## Emitted when [code]Connected[/code] is received.
 signal connected(conn: ConnectionInfo, json: Dictionary)
-
 ## Emitted when [code]PrintJSON[/code] is received.
 signal printjson(json: Dictionary, plaintext: String)
-
 ## Emitted when the connection is lost.
 signal disconnected
 #endregion
@@ -101,24 +85,20 @@ signal disconnected
 #region Other signals
 ## Signals when [member AP.status] changes.
 signal status_updated
-
 ## Signals when all required datapacks have finished loading.
 signal all_datapacks_loaded
-
 ## Emitted when a location should be cleared/deleted from the world,
 ## as it has already been collected.
 signal remove_location(loc_id: int)
-
 ## Emitted when [member AP.AP_GAME_TAGS] is updated.
 signal on_tag_change
-
 ## Emitted when an output console is attached.
 signal on_attach_console
-
 # Debug purposes
 @warning_ignore("unused_signal")
 signal _logged_message(msg: String)
 #endregion
+
 
 #region COLORS
 ## Represents a color in one of multiple formats.
@@ -131,8 +111,6 @@ class ComplexColor:
 				special = null
 				plain = null
 			else: rich = null
-	
-	
 	## The [enum AP.SpecialColor] or [code]null[/code].
 	var special :
 		set(val):
@@ -142,8 +120,6 @@ class ComplexColor:
 				plain = null
 			else:
 				special = null
-	
-	
 	## A [String] or [Color] plain value, or [code]null[/code].
 	var plain :
 		set(val):
@@ -187,13 +163,16 @@ class ComplexColor:
 	## Get the color represented by this complex color for the proviced [param node].
 	## [param node] is needed, as the representation can depend on the node's [Theme].
 	func calculate(node: Control) -> Color:
-		if rich: return AP.get_rich_color(node, rich)
-		if special: return AP.get_special_color(node, special)
+		if rich:
+			return AP.get_rich_color(node, rich)
+		if special:
+			return AP.get_special_color(node, special)
 		return AP.color_from_name(node, plain)
 		
 		
 	## A default value.
 	static var NIL := as_rich(AP.RichColor.NIL)
+
 
 ## Constants representing colors used by the AP console (as color names)
 ## Used with [AP.ComplexColor] or [method AP.get_rich_color].
@@ -202,7 +181,6 @@ enum RichColor {
 	MAGENTA, CYAN, WHITE, BLACK, SLATEBLUE,
 	PLUM, SALMON, ORANGE, GOLD,
 }
-
 ## Constants representing colors used by the AP console (as use purposes)
 ## Each of these translates to a [enum RichColor] via the [member AP.special_colors] dictionary.
 ## Used with [AP.ComplexColor] or [method AP.get_special_color].
@@ -228,14 +206,16 @@ static var special_colors: Dictionary[SpecialColor, RichColor] = {
 
 ## Checks if [param s] matches a [enum RichColor].
 static func is_rich_color_name(s: String) -> bool:
-	if s == "nil": return false
+	if s == "nil":
+		return false
 	return RichColor.keys().map(func(c): return str(c).to_lower()).has(s)
 
 
 ## Gets a [enum RichColor] from [param s]. [code]NIL[/code] is returned if the string is invalid.
 static func rich_color_from_name(s: String) -> RichColor:
 	var ind: int = RichColor.keys().map(func(c): return str(c).to_lower()).find(s)
-	if ind > -1: return RichColor.values()[ind]
+	if ind > -1:
+		return RichColor.values()[ind]
 	return RichColor.NIL
 
 
@@ -289,17 +269,13 @@ enum ItemHandling {
 ## Timestamp of the last sent DeathLink packet. Automatically updated by 
 ## [method ConnectionInfo.send_deathlink]
 var last_sent_deathlink_time: float
-
 ## Timestamp of the last sent TrapLink packet. Automatically updated by 
 ## [method ConnectionInfo.send_traplink]
 var last_sent_traplink_time: float
-
 ## The group that is used for DeathLink for this connection
 var deathlink_group: String : set = set_deathlink_group, get = get_deathlink_group
-
 ## The current connection credentials to be used.
 var creds: APCredentials = APCredentials.new()
-
 ## The current APLock object. Saving an APLock object in a save file allows you to lock it to a 
 ## particular room.
 ## [br][br]
@@ -320,7 +296,6 @@ var _socket: WebSocketPeer
 ## Can be customized by adding a node inheriting from [APConfigManager] to 
 ## [code]godot_ap/autoloads/archipelago.tscn[/code].
 var config : APConfigManager
-
 ## A save manager, designed to handle local save files tied to a specific room/slot.
 ## Null unless a node inheriting from [APSaveManager] is added to to 
 ## [code]godot_ap/autoloads/archipelago.tscn[/code].
@@ -379,17 +354,15 @@ func is_not_connected() -> bool:
 
 # Label in the [member AP.output_console] displaying the messages from [signal connect_step]
 var _connecting_part: Label 
-
 # Connection attempt counter
 var _connect_attempts := 1
-
 # If current connection attempt is using secure sockets. Alternates each attempt.
 var _wss := true 
 
 
 ## Returns the URL currently being targeted for connection.
 func get_url() -> String:
-	return "%s://%s:%s" % ["wss" if _wss else "ws",creds.ip,creds.port]
+	return "%s://%s:%s" % ["wss" if _wss else "ws", creds.ip, creds.port]
 
 
 ## Reconnect to an Archipelago room using the same information as before.
@@ -428,7 +401,7 @@ func ap_disconnect() -> void:
 	AP.close_logger()
 	if output_console:
 		var part := BaseConsole.make_text("Disconnecting...",
-				"%s:%s %s" % [creds.ip,creds.port,creds.slot],
+				"%s:%s %s" % [creds.ip, creds.port, creds.slot],
 				ComplexColor.as_special(SpecialColor.UI_MESSAGE))
 		output_console.add(part)
 		while status != APStatus.DISCONNECTED:
@@ -454,11 +427,12 @@ func force_disconnect() -> void:
 				):
 					all_datapacks_loaded.disconnect(caller)
 
+
 # Create a websocket and assign it to [member AP._socket]
 func _create_socket() -> void:
 	const BYTE_PER_MB := 1000000
 	_socket = WebSocketPeer.new()
-	_socket.inbound_buffer_size = websocket_inbuffer_mb*BYTE_PER_MB
+	_socket.inbound_buffer_size = websocket_inbuffer_mb * BYTE_PER_MB
 #endregion CONNECTION
 
 
@@ -470,7 +444,7 @@ static var logging_file: FileAccess = null
 ## Opens the GodotAP logging file, if it isn't already open.
 static func open_logger() -> void:
 	if not logging_file:
-		logging_file = FileAccess.open("user://ap/ap_log.log",FileAccess.WRITE)
+		logging_file = FileAccess.open("user://ap/ap_log.log", FileAccess.WRITE)
 
 
 ## Closes the GodotAP logging file, if its open.
@@ -511,27 +485,32 @@ static func error(s: Variant) -> void:
 
 ## Logs a message to the GodotAP log, but only if [member AP_LOG_COMMUNICATION] is true.
 func comm_log(pref: String, s: Variant) -> void:
-	if not AP_LOG_COMMUNICATION: return
+	if not AP_LOG_COMMUNICATION:
+		return
 	AP.log("[%s] %s" % [pref,str(s)])
 
 
 ## Logs a message to the GodotAP log, but only in a Debug build.
 static func dblog(s: Variant) -> void:
-	if not OS.is_debug_build(): return
+	if not OS.is_debug_build():
+		return
 	AP.log(s)
 
 
 ## Logs a warning to the GodotAP log and Godot warning console, but only in a Debug build.
 static func dbwarn(s: Variant) -> void:
-	if not OS.is_debug_build(): return
+	if not OS.is_debug_build():
+		return
 	AP.warn(s)
 
 
 ## Logs an error to the GodotAP log and Godot error console, but only in a Debug build.
 static func dberror(s: Variant) -> void:
-	if not OS.is_debug_build(): return
+	if not OS.is_debug_build():
+		return
 	AP.error(s)
 #endregion
+
 
 # Current state of the websocket connection
 var _socket_state: WebSocketPeer.State = WebSocketPeer.STATE_CLOSED
@@ -553,8 +532,7 @@ func _poll() -> void:
 				WebSocketPeer.STATE_CLOSED: # Start a new connection
 					var err: Error = _socket.connect_to_url(get_url())
 					if err:
-						AP.log(
-								"Connection to '%s' failed! Retrying (%d)" % \
+						AP.log("Connection to '%s' failed! Retrying (%d)" % \
 								[get_url(), _connect_attempts])
 						_wss = not _wss
 						if _wss:
@@ -671,7 +649,7 @@ func _handle_command(json: Dictionary) -> void:
 			var err_str := str(json["errors"])
 			if output_console and _connecting_part:
 				_connecting_part.text = "Connection Refused!"
-				_connecting_part.tooltip_text += "\nERROR(S): "+err_str
+				_connecting_part.tooltip_text += "\nERROR(S): " + err_str
 				_connecting_part = null
 			AP.log("Connection errors: %s" % err_str)
 			connect_step.emit("ERR: %s" % err_str)
@@ -811,9 +789,11 @@ func _handle_command(json: Dictionary) -> void:
 			conn.setreply.emit(json)
 			
 		"InvalidPacket":
-			AP.log("[INVALID PACKET] Error with %s of command '%s' (%s)" % [json["type"],
-					json.get("original_cmd", "?"),
-					json["text"]])
+			AP.log("[INVALID PACKET] Error with %s of command '%s' (%s)" % [
+						json["type"],
+						json.get("original_cmd", "?"),
+						json["text"],
+					])
 			
 		_:
 			AP.log("[UNHANDLED PACKET TYPE] %s" % str(json))
@@ -822,7 +802,6 @@ func _handle_command(json: Dictionary) -> void:
 #region DATAPACKS
 # Local cache of DataPackages used when connecting
 var _datapack_cache: Dictionary 
-
 # List of DataPackages that are still being waited for
 var _datapack_pending: Array[String] = [] 
 
@@ -872,7 +851,7 @@ func _send_datapack_request() -> void:
 	if _datapack_pending:
 		var game = _datapack_pending.pop_front()
 		connect_step.emit("Fetching DataPackage for '%s'..." % game)
-		var req = [{"cmd":"GetDataPackage","games":[game]}]
+		var req = [{ "cmd": "GetDataPackage", "games": [game] }]
 		send_packet(req)
 		_cache_datapacks()
 	else:
@@ -929,8 +908,13 @@ func _receive_item(index: int, item: NetworkItem) -> bool:
 			flowbox.add_text_split(BaseConsole.make_location(item.loc_id, data))
 			flowbox.add_text_split(BaseConsole.make_text(")"))
 			output_console.add(flowbox)
-		msg = "You found your %s at %s!" % [data.get_item_name(item.id),data.get_loc_name(item.loc_id)]
+		
+		msg = "You found your %s at %s!" % [
+				data.get_item_name(item.id),
+				data.get_loc_name(item.loc_id),
+		]
 		_remove_loc(item.loc_id)
+		
 	elif item.dest_player_id == item.src_player_id:
 		if output_console and _printout_recieved_items:
 			var flowbox := ConsoleHFlow.new()
@@ -941,8 +925,13 @@ func _receive_item(index: int, item: NetworkItem) -> bool:
 			flowbox.add_text_split(BaseConsole.make_location(item.loc_id, data))
 			flowbox.add_text_split(BaseConsole.make_text(")"))
 			output_console.add(flowbox)
-		msg = "You found your %s at %s!" % [data.get_item_name(item.id),data.get_loc_name(item.loc_id)]
+		
+		msg = "You found your %s at %s!" % [
+				data.get_item_name(item.id),
+				data.get_loc_name(item.loc_id)
+		]
 		_remove_loc(item.loc_id)
+		
 	else:
 		var src_data: DataCache = conn.get_gamedata_for_player(item.src_player_id)
 		if output_console and _printout_recieved_items:
@@ -957,7 +946,11 @@ func _receive_item(index: int, item: NetworkItem) -> bool:
 			flowbox.add_text_split(BaseConsole.make_text(")"))
 			output_console.add(flowbox)
 
-		msg = "%s found your %s at their %s!" % [conn.get_player_name(item.src_player_id), data.get_item_name(item.id), src_data.get_loc_name(item.loc_id)]
+		msg = "%s found your %s at their %s!" % [
+			conn.get_player_name(item.src_player_id),
+			data.get_item_name(item.id),
+			src_data.get_loc_name(item.loc_id)
+		]
 
 	conn.obtained_item.emit(item)
 
@@ -967,8 +960,8 @@ func _receive_item(index: int, item: NetworkItem) -> bool:
 	if conn.received_items.size() == index:
 		conn.received_items.append(item)
 	else:
-		if conn.received_items.size() < index+1:
-			conn.received_items.resize(index+1)
+		if conn.received_items.size() < index + 1:
+			conn.received_items.resize(index + 1)
 		conn.received_items[index] = item
 
 	return true
@@ -1006,7 +999,7 @@ func on_removed(loc_name: String, proc: Callable) -> void:
 func collect_location(loc_id: int) -> void:
 	if _is_nongame_client: return
 	_printout_recieved_items = false
-	send_command("LocationChecks", {"locations":[loc_id]})
+	send_command("LocationChecks", { "locations": [loc_id] })
 	_remove_loc(loc_id)
 
 
@@ -1015,7 +1008,7 @@ func collect_locations(locs: Array[int]) -> void:
 	if _is_nongame_client: return
 	if locs.is_empty(): return
 	_printout_recieved_items = false
-	send_command("LocationChecks", {"locations":locs})
+	send_command("LocationChecks", { "locations": locs })
 	for loc_id in locs:
 		_remove_loc(loc_id)
 
@@ -1031,7 +1024,7 @@ func location_checked(loc_id: int, def := false) -> bool:
 	return conn.slot_locations.get(loc_id, def)
 
 
-## Returns a list of all location ids.
+## Returns a list of all location IDs.
 func location_list() -> Array[int]:
 	var arr: Array[int] = []
 	arr.assign(conn.slot_locations.keys())
@@ -1049,9 +1042,7 @@ func ap_reconnect_to_save() -> void:
 				s += "Please reconnect to the room previously used by this save file!"
 			else:
 				s += "Connect to a room when ready."
-			output_console.add(BaseConsole.make_text(
-					s,
-					"",
+			output_console.add(BaseConsole.make_text(s, "",
 					ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 	else:
 		ap_reconnect()
@@ -1070,12 +1061,12 @@ func _notification(what):
 #region CONSOLE
 ## Container for the current output console.
 var output_console_container: ConsoleContainer = null 
-
-
 ## The currently attached GodotAP console, if one exists.
 var output_console: BaseConsole :
-	get: return cmd_manager.console
-	set(val): cmd_manager.console = val
+	get:
+		return cmd_manager.console
+	set(val):
+		cmd_manager.console = val
 
 
 ## Loads [param console] as the active console and makes it the active scene in [param tree].
@@ -1094,15 +1085,19 @@ func load_packed_console_as_scene(tree: SceneTree, console: PackedScene) -> bool
 ## Loads [param console_scene] as the active console.
 ## The window this node is in will be considered the console window.
 func load_console(console_scene: Node, as_child := true) -> bool:
-	if output_console: return false
+	if output_console:
+		return false
+	
 	if console_scene is ConsoleContainer:
 		output_console_container = console_scene
+	
 	elif console_scene is Node:
 		output_console_container = Util.for_all_nodes(console_scene,
 			func(node):
 				return node is ConsoleContainer)
 		if not output_console_container:
 			return false
+	
 	if as_child: add_child.call_deferred(console_scene)
 	console_scene.ready.connect(func():
 		output_console = output_console_container.console
@@ -1113,12 +1108,14 @@ func load_console(console_scene: Node, as_child := true) -> bool:
 		output_console.tree_exiting.connect(close_console)
 		output_console_container.typing_bar.cmd_manager = cmd_manager
 		on_attach_console.emit())
+	
 	return true
 
 
 ## Opens a default Archipelago text console popup.
 func open_console() -> void:
-	if output_console: return
+	if output_console:
+		return
 	load_console(load("res://godot_ap/ui/ap_console_window.tscn").instantiate())
 
 
@@ -1145,7 +1142,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 					ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 		else:
 			if _ensure_connected(mgr.console):
-				send_command("Say", {"text":msg}))
+				send_command("Say", { "text": msg }))
 	
 	if can_connect:
 		cmd_manager.register_command(ConsoleCommand.new("/connect")
@@ -1166,14 +1163,14 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 				if command_args.size() != 4:
 					cmd.output_usage(mgr.console)
 				else:
-					var ipport = command_args[1].split(":",1)
+					var ipport = command_args[1].split(":", 1)
 					if ipport.is_empty():
 						cmd.output_usage(mgr.console)
 					if ipport.size() == 1 and ipport[0].length() == 5:
-						ipport = [creds.ip,ipport[0]]
+						ipport = [creds.ip, ipport[0]]
 					elif ipport.size() == 1:
 						ipport.append("38281")
-					ap_connect(ipport[0],ipport[1],command_args[2],command_args[3])))
+					ap_connect(ipport[0], ipport[1], command_args[2], command_args[3])))
 		
 		cmd_manager.register_command(ConsoleCommand.new("/reconnect")
 			.add_help("", "Refreshes the connection to the Archipelago server")
@@ -1192,12 +1189,12 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 						ap_disconnect()))
 	
 	cmd_manager.register_command(ConsoleCommand.new("/locations")
-		.add_help_cond(
-				"[filter]",
+		.add_help_cond("[filter]",
 				"Lists all locations (optionally matching a filter) for the current slot's game.",
 				is_ap_connected)
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, msg: String):
-			if not _ensure_connected(mgr.console): return
+			if not _ensure_connected(mgr.console):
+				return
 			var filt := msg.substr(11)
 			var data: DataCache = conn.get_gamedata_for_player()
 			
@@ -1207,9 +1204,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 			
 			var title := "LOCATIONS"
 			if filt: title += " (%s)" % filt
-			var folder := BaseConsole.make_foldable(
-					"[ %s ]" % title,
-					msg,
+			var folder := BaseConsole.make_foldable("[ %s ]" % title, msg,
 					ComplexColor.as_special(SpecialColor.UI_MESSAGE))
 			mgr.console.add(folder)
 			folder.add(grid)
@@ -1241,9 +1236,12 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 			))
 	
 	cmd_manager.register_command(ConsoleCommand.new("/items")
-		.add_help_cond("[filter]", "Lists all items (optionally matching a filter) for the current slot's game.", is_ap_connected)
+		.add_help_cond("[filter]",
+				"Lists all items (optionally matching a filter) for the current slot's game.",
+				is_ap_connected)
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, msg: String):
-			if not _ensure_connected(mgr.console): return
+			if not _ensure_connected(mgr.console):
+				return
 			var filt := msg.substr(7)
 			var data: DataCache = conn.get_gamedata_for_player()
 
@@ -1253,7 +1251,8 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 
 			var title := "ITEMS"
 			if filt: title += " (%s)" % filt
-			var folder := BaseConsole.make_foldable("[ %s ]" % title, msg, ComplexColor.as_special(SpecialColor.UI_MESSAGE))
+			var folder := BaseConsole.make_foldable("[ %s ]" % title, msg,
+					ComplexColor.as_special(SpecialColor.UI_MESSAGE))
 			mgr.console.add(folder)
 			folder.add(grid)
 			folder.fold(false)
@@ -1264,7 +1263,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 				if dict:
 					dict[item.flags] = dict.get(item.flags, 0) + 1
 				else:
-					item_dict[item.id] = {item.flags: 1}
+					item_dict[item.id] = { item.flags: 1 }
 
 			var ids: Array = data.item_name_to_id.values()
 			var _index_dict := {}
@@ -1307,9 +1306,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 								var c1 := BaseConsole.make_item(iid, flags, data)
 								grid.add_child(c1)
 								grid.add_child(
-										BaseConsole.make_text(
-												"x%d" % flag_options[flags],
-												"",
+										BaseConsole.make_text("x%d" % flag_options[flags], "",
 												ComplexColor.as_rich(c1.rich_color)))
 						else:
 							grid.add_child(BaseConsole.make_text(itm_name, "Item %d" % iid))
@@ -1317,8 +1314,8 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 								grid.add_child(Control.new())
 			elif filt:
 				grid.add_child(BaseConsole.make_text(
-					"No%s items found!" % (" matching" if filt else ""),
-					filt_ttip, ComplexColor.as_rich(AP.RichColor.SALMON)))
+					"No%s items found!" % (" matching" if filt else ""), filt_ttip, 
+					ComplexColor.as_rich(AP.RichColor.SALMON)))
 			mgr.console.add_header_spacing()
 			))
 			
@@ -1352,7 +1349,8 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 			.add_disable(func(): return _is_nongame_client)
 			.set_autofill(_autofill_locs)
 			.set_call(func(mgr: CommandManager, cmd: ConsoleCommand, msg: String):
-				if not _ensure_connected(mgr.console): return
+				if not _ensure_connected(mgr.console):
+					return
 				var command_args = msg.split(" ", true, 1)
 				if command_args.size() > 1 and command_args[1]:
 					var data = conn.get_gamedata_for_player(conn.player_id)
@@ -1360,9 +1358,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 						var loc_name := data.get_loc_name(loc)
 						if loc_name.strip_edges().to_lower() == command_args[1].strip_edges().to_lower():
 							if conn.slot_locations[loc]:
-								mgr.console.add(BaseConsole.make_text(
-										"Location already sent!",
-										"",
+								mgr.console.add(BaseConsole.make_text("Location already sent!", "",
 										ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 							else:
 								mgr.console.add(BaseConsole.make_text(
@@ -1375,7 +1371,8 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 							"Location '%s' not found! Check spelling?" % command_args[1].strip_edges(),
 							"",
 							ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
-				else: cmd.output_usage(mgr.console)))
+				else:
+					cmd.output_usage(mgr.console)))
 		
 		cmd_manager.register_command(ConsoleCommand.new("/lock_info").debug()
 			.add_help("", "Prints the connection lock info")
@@ -1396,25 +1393,26 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 			.set_autofill(func(msg: String):
 				var args = msg.split(" ", 2)
 				var arg_count := args.size()
-				while args.size() < 3: args.append("")
+				while args.size() < 3:
+					args.append("")
 				var ret: Array[String] = []
 				var opts: Array[String] = []
 				if arg_count < 3:
-					opts.assign(["TextOnly","HintGame","Tracker",get_deathlink_tag()])
+					opts.assign(["TextOnly", "HintGame", "Tracker", get_deathlink_tag()])
 					var matched := false
 					for opt in opts:
 						if args[1] == opt:
 							matched = true
 							break
 						if opt.to_lower().begins_with(args[1].to_lower()):
-							ret.append("%s %s" % [args[0],opt])
+							ret.append("%s %s" % [args[0], opt])
 					if not matched:
 						return ret
 					ret.clear()
-				opts.assign(["true","false"])
+				opts.assign(["true", "false"])
 				for opt in opts:
 					if arg_count < 3 or opt.to_lower().begins_with(args[2].to_lower()):
-						ret.append("%s %s %s" % [args[0],args[1],opt])
+						ret.append("%s %s %s" % [args[0], args[1], opt])
 				return ret)
 			.set_call(func(mgr: CommandManager, cmd: ConsoleCommand, msg: String):
 				var args = msg.split(" ", true, 2)
@@ -1425,36 +1423,33 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 					return
 				if args.size() > 2:
 					var s = args[2].to_lower()
-					if s == "false": state = false
+					if s == "false":
+						state = false
 					elif s != "true":
 						cmd.output_usage(mgr.console)
 						return
 				set_tag(tag, state)
-				mgr.console.add(BaseConsole.make_text(
-						"Set tag '%s' to %s" % [args[1],state],
-						"",
+				mgr.console.add(BaseConsole.make_text("Set tag '%s' to %s" % [args[1], state], "",
 						ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
 				
 		cmd_manager.register_command(ConsoleCommand.new("/tags").debug()
 			.add_help("", "Prints out your connection tags")
 			.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
-					mgr.console.add(BaseConsole.make_text(str(AP_GAME_TAGS),
-					"",
+					mgr.console.add(BaseConsole.make_text(str(AP_GAME_TAGS), "",
 					ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
 				
 		cmd_manager.register_command(ConsoleCommand.new("/slot_data").debug()
 			.add_help("", "Prints slot_data")
 			.add_disable(is_not_connected)
 			.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
-					var folder := BaseConsole.make_foldable(
-							"[ SLOT_DATA ]", "/slot_data",
+					var folder := BaseConsole.make_foldable("[ SLOT_DATA ]", "/slot_data",
 							ComplexColor.as_special(SpecialColor.UI_MESSAGE))
 					mgr.console.add(folder)
 					folder.add(BaseConsole.make_indented_block(
-							JSON.stringify(Archipelago.conn.slot_data, "\t"), 
-							25))
+							JSON.stringify(Archipelago.conn.slot_data, "\t"), 25))
 					folder.fold(false)
 					))
+		
 		cmd_manager.setup_debug_commands()
 
 
@@ -1521,19 +1516,21 @@ static func get_item_classification(flags: int) -> String:
 		_: # If multiple bits are combined, make a comma-delimited list.
 			var s := ""
 			for q in 3:
-				if flags & (1<<q):
+				if flags & (1 << q):
 					if s:
 						s += ","
-					s += get_item_classification(1<<q)
+					s += get_item_classification(1 << q)
 			return s
 
 
 # no-op
-func _cmd_nil(_msg: String): pass
+func _cmd_nil(_msg: String):
+	pass
 
 
 func _autofill_locs(msg: String) -> Array[String]:
-	if not conn: return []
+	if not conn:
+		return []
 	var args = msg.split(" ", true, 1)
 	var data: DataCache = conn.get_gamedata_for_player(conn.player_id)
 	var locs: Array[String] = []
@@ -1543,13 +1540,14 @@ func _autofill_locs(msg: String) -> Array[String]:
 		var id: int = data.location_name_to_id[locs[ind]]
 		if location_checked(id, true):
 			locs.pop_at(ind)
-		else: ind += 1
+		else:
+			ind += 1
 	if args.size() > 1 and args[1]:
 		var arg_str = args[1].strip_edges().to_lower()
 		if arg_str.begins_with("\""):
 			arg_str = arg_str.substr(1)
 		if arg_str.ends_with("\""):
-			arg_str = arg_str.substr(0,arg_str.length()-1)
+			arg_str = arg_str.substr(0, arg_str.length() - 1)
 		var q := 0
 		while q < locs.size():
 			if not locs[q].strip_edges().to_lower().begins_with(arg_str):
@@ -1557,7 +1555,7 @@ func _autofill_locs(msg: String) -> Array[String]:
 			else:
 				q += 1
 	for q in locs.size():
-		locs[q] = "%s %s" % [args[0],locs[q]]
+		locs[q] = "%s %s" % [args[0], locs[q]]
 	return locs
 
 
@@ -1572,7 +1570,7 @@ func _autofill_items(msg: String) -> Array[String]:
 		if arg_str.begins_with("\""):
 			arg_str = arg_str.substr(1)
 		if arg_str.ends_with("\""):
-			arg_str = arg_str.substr(0,arg_str.length()-1)
+			arg_str = arg_str.substr(0, arg_str.length() - 1)
 		var q := 0
 		while q < itms.size():
 			if not itms[q].strip_edges().to_lower().begins_with(arg_str):
@@ -1580,7 +1578,7 @@ func _autofill_items(msg: String) -> Array[String]:
 			else:
 				q += 1
 	for q in itms.size():
-		itms[q] = "%s %s" % [args[0],itms[q]]
+		itms[q] = "%s %s" % [args[0], itms[q]]
 	return itms
 
 
@@ -1590,7 +1588,7 @@ var _is_nongame_client := false
 
 func _update_tags() -> void:
 	if status == APStatus.PLAYING:
-		send_command("ConnectUpdate", {"tags":AP_GAME_TAGS})
+		send_command("ConnectUpdate", { "tags": AP_GAME_TAGS })
 	_is_nongame_client = false
 	for tag in AP_GAME_TAGS:
 		if tag == "TextOnly" or tag == "Tracker" or tag == "HintGame":
@@ -1642,14 +1640,16 @@ func set_misc_tags(tags: Array[String]) -> void:
 func _ensure_connected(console: BaseConsole) -> bool:
 	if status == APStatus.PLAYING:
 		return true
-	console.add(BaseConsole.make_text("Not connected to Archipelago! Please connect first!", "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
+	console.add(BaseConsole.make_text("Not connected to Archipelago! Please connect first!", "",
+			ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 	return false
 
 
 ## Changes this connection's DeathLink group.
 ## Will only send/receive deaths with other clients in the same group.
 func set_deathlink_group(group: String) -> void:
-	if group == deathlink_group: return
+	if group == deathlink_group:
+		return
 	var deathlink := is_deathlink()
 	if deathlink:
 		set_deathlink(false)
@@ -1707,7 +1707,7 @@ enum ClientStatus {
 ## Set the current Archipelago status.
 ## Set to [code]CLIENT_GOAL[/code] when the player has won.
 func set_client_status(stat: ClientStatus) -> void:
-	send_command("StatusUpdate", {"status": stat})
+	send_command("StatusUpdate", { "status": stat })
 
 
 ## Gets the status of the specified hint.
@@ -1715,8 +1715,10 @@ func find_hint_status(loc_id: int, default := NetworkHint.Status.UNSPECIFIED) ->
 	if location_checked(loc_id):
 		return NetworkHint.Status.FOUND
 	for hint in conn.hints:
-		if hint.item.src_player_id == conn.player_id and \
-			hint.item.loc_id == loc_id:
+		if (
+			hint.item.src_player_id == conn.player_id
+			and hint.item.loc_id == loc_id
+		):
 			return hint.status
 	return default
 
@@ -1724,8 +1726,10 @@ func find_hint_status(loc_id: int, default := NetworkHint.Status.UNSPECIFIED) ->
 # Used to override incoming packets from the Archipelago server.
 func _preparse_json(json: Dictionary) -> void:
 	var data: Array = json.get("data")
-	if not data: return
-	if data.size() != 1: return # Optimize, don't check if we know we don't care
+	if not data:
+		return
+	if data.size() != 1:
+		return # Optimize, don't check if we know we don't care
 
 	# Alter the 'compressed websocket' warning, to remove the part telling players to inform the developer, as it is a known issue.
 	if data[0]["text"] == "Warning: your client does not support compressed websocket connections! It may stop working in the future. If you are a player, please report this to the client\'s developer.":

--- a/godot_ap/autoloads/archipelago.gd
+++ b/godot_ap/autoloads/archipelago.gd
@@ -1,79 +1,124 @@
+class_name AP
+extends Node
 ## The main Archipelago interface class.
 ##
-## Access non-static members via the `Archipelago` autoload,
-## which should be loaded as `godot_ap/autoloads/archipelago.tscn`.
-class_name AP extends Node
+## Access non-static members via the [code]Archipelago[/code] autoload,
+## which should be loaded as [code]godot_ap/autoloads/archipelago.tscn[/code].
+## [br][br]
+## Additional signals can be found on [member AP.conn].
 
-## The game name to connect to. Empty string for `TextOnly` / `Tracker`/ `HintGame` clients.
+## The game name to connect to. Empty string for [code]TextOnly[/code] / [code]Tracker[/code] /
+## [code]HintGame[/code] clients.
 @export var AP_GAME_NAME := ""
+
 ## The tags for your game.
 @export var AP_GAME_TAGS: Array[String] = []
+
 ## The version of your client. Arbitrary number for you to manage.
 @export var AP_CLIENT_VERSION := Version.val(0,0,0)
+
 ## The target AP version. Not arbitrary - used in `Connect` packet.
 @export var AP_VERSION := Version.val(0,5,0)
-## The ItemHandling to use when connecting.
+
+## The [enum ItemHandling] to use when connecting.
 @export var AP_ITEM_HANDLING := ItemHandling.ALL
+
+
 @export_group("Extra Options")
 ## Aliases for Traps in TrapLink. When the key is received, the value will be used instead.
 @export var TRAP_LINK_ALIASES: Dictionary[String, String]
+
+
 @export_group("Client Settings")
 ## Prints what items have been previously collected when reconnecting to a slot.
 @export var AP_PRINT_ITEMS_ON_CONNECT := false
+
 ## Hide item send messages that don't involve the client.
 @export var AP_HIDE_NONLOCAL_ITEMSENDS := true
+
 ## Automatically opens a default AP text console.
 @export var AP_AUTO_OPEN_CONSOLE := false
+
 ## Show items that are both progression and useful with their own color
 @export var AP_ENABLE_PROGUSEFUL := false
+
 
 @export_subgroup("UI")
 ## Automatically open the Connection box when the console opens
 @export var AP_CONSOLE_CONNECTION_OPEN := false
+
 ## Automatically open/close the Connection box based on connected status
 @export var AP_CONSOLE_CONNECTION_AUTO := true
+
 
 @export_subgroup("Logging")
 ## Enables additional logging.
 @export var AP_LOG_COMMUNICATION := false
+
 ## Enables additional logging.
 @export var AP_LOG_RECIEVED := false
+
+
 @export_subgroup("Data Packs")
 ## If true, datapackage local files will be stringified in a readable mode.
 @export var READABLE_DATAPACK_FILES := true
+
 ## Which fields should be saved from received DataPacks.
-@export var datapack_cached_fields: Array[String] = ["item_name_to_id","location_name_to_id","checksum"]
+@export var datapack_cached_fields: Array[String] = [
+	"item_name_to_id",
+	"location_name_to_id",
+	"checksum",
+]
+
+
 @export_group("Misc")
-## Size, in MB, of the websocket inbound buffer. Raising may help if large datapackages are causing disconnections.
+## Size, in MB, of the websocket inbound buffer.
+## Raising may help if large datapackages are causing disconnections.
 @export_range(5, 500, 1, "or_greater", "hide_slider") var websocket_inbuffer_mb: int = 50
+
+
 @export_group("")
 
+
 @onready var hang_clock: Timer = $HangTimer
+
 
 #region Connection packets
 # See `ConnectionInfo` (Archipelago.conn) for more signals
 ## Emitted before connection is attempted
 signal preconnect
-## Emitted when `RoomInfo` is received
+
+## Emitted when [code]RoomInfo[/code] is received
 signal roominfo(conn: ConnectionInfo, json: Dictionary)
-## Emitted when `ConnectionRefused` is received
+
+## Emitted when [code]ConnectionRefused[/code] is received
 signal connectionrefused(conn: ConnectionInfo, json: Dictionary)
-## Emitted when `Connected` is received
+
+## Emitted when [code]Connected[/code] is received
 signal connected(conn: ConnectionInfo, json: Dictionary)
-## Emitted when `PrintJSON` is received
+
+## Emitted when [code]PrintJSON[/code] is received
 signal printjson(json: Dictionary, plaintext: String)
+
 ## Emitted when the connection is lost
 signal disconnected
 #endregion
+
+
 #region Other signals
-## Signals when 'status' changes
+## Signals when [member AP.status] changes
 signal status_updated
+
 ## Signals when all required datapacks have finished loading
 signal all_datapacks_loaded
-## Emitted when a location should be cleared/deleted from the world, as it has been "already collected"
+
+## Emitted when a location should be cleared/deleted from the world,
+## as it has been "already collected"
 signal remove_location(loc_id: int)
-## Emitted when the connection tags are updated
+
+## Emitted when [member AP.AP_GAME_TAGS] is updated
 signal on_tag_change
+
 ## Emitted when an output console is attached
 signal on_attach_console
 
@@ -86,7 +131,7 @@ signal _logged_message(msg: String)
 #region COLORS
 ## Represents a color in one of multiple formats.
 class ComplexColor:
-	## The 'RichColor' or 'null'
+	## The [RichColor] or [code]null[/code]
 	var rich :
 		set(val):
 			if val is RichColor:
@@ -94,7 +139,9 @@ class ComplexColor:
 				special = null
 				plain = null
 			else: rich = null
-	## The 'SpecialColor' or 'null'
+	
+	
+	## The [SpecialColor] or [code]null[/code]
 	var special :
 		set(val):
 			if val is SpecialColor:
@@ -103,7 +150,9 @@ class ComplexColor:
 				plain = null
 			else:
 				special = null
-	## A 'String' or 'Color' plain value, or 'null'
+	
+	
+	## A [String] or [Color] plain value, or [code]null[/code]
 	var plain :
 		set(val):
 			if val is String:
@@ -113,50 +162,67 @@ class ComplexColor:
 			elif val is Color:
 				plain = str(val)
 			else: plain = null
-	## Construct a 'ComplexColor' representing a 'RichColor' value
+	
+	
+	## Construct a [ComplexColor] representing a [RichColor] value
 	static func as_rich(color: RichColor) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.rich = color
 		return ret
-	## Construct a 'ComplexColor' representing a 'SpecialColor' value
+
+
+	## Construct a [ComplexColor] representing a [SpecialColor] value
 	static func as_special(color: SpecialColor) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.special = color
 		return ret
-	## Construct a 'ComplexColor' representing a 'String' value
+
+
+	## Construct a [ComplexColor] representing a [String] value
 	static func as_plain_str(color: String) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.plain = color
 		return ret
-	## Construct a 'ComplexColor' representing a 'Color' value
+
+
+	## Construct a [ComplexColor] representing a [Color] value
 	static func as_plain_col(color: Color) -> ComplexColor:
 		var ret := ComplexColor.new()
 		ret.plain = color
 		return ret
-	## Get the color represented by this 'ComplexColor' for the given 'Node'.
-	## The node is needed, as the representation can depend on the node's 'Theme'.
+
+
+	## Get the color represented by this [ComplexColor] for a given [param node].
+	## The node is needed, as the representation can depend on the node's [Theme].
 	func calculate(node: Control) -> Color:
 		if rich: return AP.get_rich_color(node, rich)
 		if special: return AP.get_special_color(node, special)
 		return AP.color_from_name(node, plain)
+		
+		
 	## a default value
 	static var NIL := as_rich(AP.RichColor.NIL)
+
+
 ## Constants representing colors used by the AP console (as color names)
-## Used with 'ComplexColor' or 'get_rich_color()'
+## Used with [ComplexColor] or [method AP.get_rich_color]
 enum RichColor {
 	NIL, RED, GREEN, YELLOW, BLUE,
 	MAGENTA, CYAN, WHITE, BLACK, SLATEBLUE,
 	PLUM, SALMON, ORANGE, GOLD,
 }
+
+
 ## Constants representing colors used by the AP console (as use purposes)
-## Each of these translates to a 'RichColor' via the 'special_colors' dictionary.
-## Used with 'ComplexColor' or 'get_special_color()'
+## Each of these translates to a [RichColor] via the [member AP.special_colors] dictionary.
+## Used with [ComplexColor] or [method AP.get_special_color]
 enum SpecialColor {
 	ANY_PLAYER, OWN_PLAYER, ITEM_PROG, ITEM, ITEM_USEFUL, ITEM_TRAP, ITEM_PROGUSEFUL,
 	LOCATION, UI_MESSAGE, DEBUG,
 }
 
-## Mapping of 'SpecialColor' values to 'RichColor' values.
+
+## Mapping of [SpecialColor] values to [RichColor] values.
 static var special_colors: Dictionary[SpecialColor, RichColor] = {
 	SpecialColor.ANY_PLAYER: RichColor.YELLOW,
 	SpecialColor.OWN_PLAYER: RichColor.MAGENTA,
@@ -170,87 +236,144 @@ static var special_colors: Dictionary[SpecialColor, RichColor] = {
 	SpecialColor.DEBUG: RichColor.MAGENTA,
 }
 
-## Checks if a string matches a RichColor
+
+## Checks if [param s] matches a [RichColor].
 static func is_rich_color_name(s: String) -> bool:
 	if s == "nil": return false
 	return RichColor.keys().map(func(c): return str(c).to_lower()).has(s)
-## Gets a RichColor from a string. 'RichColor.NIL' is returned if the string is invalid.
+
+
+## Gets a [RichColor] from [param s]. [member RichColor.NIL] is returned if the string is invalid.
 static func rich_color_from_name(s: String) -> RichColor:
 	var ind: int = RichColor.keys().map(func(c): return str(c).to_lower()).find(s)
 	if ind > -1: return RichColor.values()[ind]
 	return RichColor.NIL
+
+
+## Gets a [Color] from the provided [paran node]'s theme, and returns [param default] if none 
+## exists.
 static func _get_rich_color_name(node: Control, s: String, default := Color.WHITE) -> Color:
 	if node.has_theme_color("rich_%s" % s, "Console_Label"):
 		return node.get_theme_color("rich_%s" % s, "Console_Label")
 	return default
-## Gets a 'Color' represented by a 'RichColor'. Uses the 'Theme' of the specified node.
+
+
+## Gets a [Color] represented by a [RichColor]. Uses the [Theme] of the specified [param node].
 static func get_rich_color(node: Control, c: RichColor, default := Color.WHITE) -> Color:
 	if c == RichColor.NIL:
 		return default
 	return _get_rich_color_name(node, RichColor.find_key(c).to_lower(), default)
-## Gets a 'Color' represented by a 'SpecialColor'. Uses the 'Theme' of the specified node.
+
+
+## Gets a [Color] represented by a [SpecialColor]. Uses the [Theme] of the specified [param node].
 static func get_special_color(node: Control, c: SpecialColor, default := Color.WHITE) -> Color:
 	return get_rich_color(node, special_colors.get(c, RichColor.NIL), default)
-## Returns the 'RichColor' that the specified 'SpecialColor' represents.
+
+
+## Returns the [RichColor] that the specified [SpecialColor] represents.
 static func special_to_rich_color(c: SpecialColor, default := RichColor.NIL) -> RichColor:
 	return special_colors.get(c, default)
-## Gets a 'Color' from a 'String'. Will use a 'RichColor' if one matches, else falls back to Godot's 'Color.from_string()' implementation.
+
+
+## Gets a [Color] from a [String]. Will use a [RichColor] if one matches, else falls back to Godot's
+## [method Color.from_string] implementation.
 static func color_from_name(node: Control, colname: String, def := Color.TRANSPARENT) -> Color:
 	return _get_rich_color_name(node, colname, Color.from_string(colname, def))
 #endregion COLORS
 
+
 ## The Archipelago item handling values.
 enum ItemHandling {
-	NONE = 0, ## Don't receive any items from the server.
-	OTHER = 1, ## Receive your items in other worlds from the server.
-	OWN_AND_OTHER = 3, ## Receive your items from your world and other worlds from the server.
-	STARTING_AND_OTHER = 5, ## Receive your items from your starting inventory and other worlds from the server.
-	ALL = 7, ## Receive your items from your starting inventory, your world, and other worlds from the server.
+	## Don't receive any items from the server.
+	NONE = 0,
+	## Receive your items from other worlds from the server.
+	OTHER = 1, 
+	## Receive your items from your world and other worlds from the server.
+	OWN_AND_OTHER = 3, 
+	## Receive your items from your starting inventory and other worlds from the server.
+	STARTING_AND_OTHER = 5,
+	## Receive all your items from the server.
+	ALL = 7, 
 }
 
-## Timestamp of the last sent DeathLink packet. Automatically updated by 'ConnectionInfo.send_deathlink'.
+
+## Timestamp of the last sent DeathLink packet. Automatically updated by 
+## [method ConnectionInfo.send_deathlink]
 var last_sent_deathlink_time: float
-## Timestamp of the last sent TrapLink packet. Automatically updated by 'ConnectionInfo.send_traplink'.
+
+
+## Timestamp of the last sent TrapLink packet. Automatically updated by 
+## [method ConnectionInfo.send_traplink]
 var last_sent_traplink_time: float
+
 
 ## The group that is used for DeathLink for this connection
 var deathlink_group: String : set = set_deathlink_group, get = get_deathlink_group
 
+
 ## The current connection credentials to be used
 var creds: APCredentials = APCredentials.new()
-## The current APLock object. A default lock object is `unlocked`.
-## If an `unlocked` object is set here, it will be `locked` when you connect to a slot.
-## If a `locked` object is set here, it will disallow you from connecting to any slot different from the one it locked to.
-## Saving an APLock object in a save file allows you to lock it to a particular room.
-## `save_manager` can handle the lock for you, along with handling local save files.
+
+
+## The current [APLock] object. A default lock object is [code]unlocked[/code].
+## If an [code]unlocked[/code] object is set here, it will be [code]locked[/code] when you connect
+## to a slot.
+## If a [code]locked[/code] object is set here, it will disallow you from connecting to any slot
+## different from the one it locked to.
+## Saving an [APLock] object in a save file allows you to lock it to a particular room.
+## [code]save_manager[/code] can handle the lock for you, along with handling local save files.
 var aplock: APLock = null
 
+
+## The websocket connection to the server.
 var _socket: WebSocketPeer
+
 
 ## A config manager, designed to handle configs not tied to a specific save file.
 ## Will always exist, as GodotAP's own configs are managed by this.
-## Can be customized by adding a node inheriting from 'APConfigManager' to 'godot_ap/autoloads/archipelago.tscn'
+## Can be customized by adding a node inheriting from [APConfigManager] to 
+## [code]godot_ap/autoloads/archipelago.tscn[/code]
 var config : APConfigManager
 
+
 ## A save manager, designed to handle local save files tied to a specific room/slot.
-## Null unless a node inheriting from 'APSaveManager' is added to to 'godot_ap/autoloads/archipelago.tscn'
-var save_manager : APSaveManager ## Can be 'null' if not provided in 'godot_ap/autoloads/archipelago.tscn'
+## Null unless a node inheriting from [APSaveManager] is added to to 
+## [code]godot_ap/autoloads/archipelago.tscn[/code].
+## [br]
+## Can be [code]null[/code] if not provided in [code]godot_ap/autoloads/archipelago.tscn[/code]
+var save_manager : APSaveManager
+
 
 #region CONNECTION
-var conn: ConnectionInfo ## The active Archipelago connection
+## The active Archipelago connection
+var conn: ConnectionInfo 
 
-## Emits strings representing stages of the connection process. Useful for displaying connection progress to users.
+
+## Emits strings representing stages of the connection process.
+## Useful for displaying connection progress to users.
 signal connect_step(message: String)
+
+
 ## The possible connection status states.
 enum APStatus {
-	DISCONNECTED, ## Not connected to any Archipelago server
-	SOCKET_CONNECTING, ## Socket attempting to connect
-	CONNECTING, ## Socket connected, trying to connect with server
-	CONNECTED, ## Connected with server, authenticating for selected slot
-	PLAYING, ## Authenticated and acively playing
-	DISCONNECTING, ## Attempting to disconnect from the server
+	## Not connected to any Archipelago server
+	DISCONNECTED,
+	## Socket attempting to connect
+	SOCKET_CONNECTING, 
+	## Socket connected, trying to connect with server
+	CONNECTING, 
+	## Connected with server, authenticating for selected slot
+	CONNECTED, 
+	## Authenticated and acively playing
+	PLAYING, 
+	## Attempting to disconnect from the server
+	DISCONNECTING, 
 }
+
+
 var _queue_reconnect := false
+
+
 ## The current connection status.
 var status: APStatus = APStatus.DISCONNECTED :
 	set(val):
@@ -263,21 +386,33 @@ var status: APStatus = APStatus.DISCONNECTED :
 				_queue_reconnect = false
 				ap_reconnect()
 
-## Returns true if there is an active Archipelago connection
+
+## Returns [code]true[/code] if there is an active Archipelago connection
 func is_ap_connected() -> bool:
 	return status == APStatus.PLAYING
-## Returns true if there is no active Archipelago connection
+
+
+## Returns [code]true[/code] if there is no active Archipelago connection
 func is_not_connected() -> bool:
 	return status != APStatus.PLAYING
 
-var _connecting_part: Label # Label in the 'output_console' displaying the messages from 'connect_step'
 
-var _connect_attempts := 1 # Connection attempt counter
-var _wss := true # If current connection attempt is using secure sockets. Alternates each attempt.
+# Label in the [member AP.output_console] displaying the messages from [signal connect_step]
+var _connecting_part: Label 
+
+
+# Connection attempt counter
+var _connect_attempts := 1
+
+
+# If current connection attempt is using secure sockets. Alternates each attempt.
+var _wss := true 
+
 
 ## Returns the URL currently being targetted for connection
 func get_url() -> String:
 	return "%s://%s:%s" % ["wss" if _wss else "ws",creds.ip,creds.port]
+
 
 ## Reconnect to Archipelago with the same information as before
 func ap_reconnect() -> void:
@@ -291,6 +426,7 @@ func ap_reconnect() -> void:
 	_wss = true
 	preconnect.emit()
 
+
 ## Connect to Archipelago with the specified connection information
 func ap_connect(room_ip: String, room_port: String, slot_name: String, room_pwd := "") -> void:
 	if status != APStatus.DISCONNECTED:
@@ -298,6 +434,7 @@ func ap_connect(room_ip: String, room_port: String, slot_name: String, room_pwd 
 	AP.open_logger()
 	creds.update(room_ip, room_port, slot_name, room_pwd)
 	ap_reconnect()
+
 
 ## Disconnect from Archipelago
 func ap_disconnect() -> void:
@@ -312,13 +449,16 @@ func ap_disconnect() -> void:
 		hang_clock.start(hang_clock.wait_time)
 	AP.close_logger()
 	if output_console:
-		var part := BaseConsole.make_text("Disconnecting...","%s:%s %s" % [creds.ip,creds.port,creds.slot], ComplexColor.as_special(SpecialColor.UI_MESSAGE))
+		var part := BaseConsole.make_text("Disconnecting...",
+				"%s:%s %s" % [creds.ip,creds.port,creds.slot],
+				ComplexColor.as_special(SpecialColor.UI_MESSAGE))
 		output_console.add(part)
 		while status != APStatus.DISCONNECTED:
 			await status_updated
 		part.text = "Disconnected from AP."
 
-## Forcibly disconnect. Use 'ap_disconnect()' to disconnect normally if possible.
+
+## Forcibly disconnect. Use [method AP.ap_disconnect] to disconnect normally if possible.
 func force_disconnect() -> void:
 	if status == APStatus.DISCONNECTED: return
 	_socket.close()
@@ -330,86 +470,123 @@ func force_disconnect() -> void:
 		if c["flags"] & CONNECT_ONE_SHOT:
 			var caller: Callable = c["callable"]
 			if caller.get_method() == "send_command" and caller.get_object() == self:
-				if caller.get_bound_arguments_count() == 2 and caller.get_bound_arguments()[0] == "Connect":
+				if (
+					caller.get_bound_arguments_count() == 2 
+					and caller.get_bound_arguments()[0] == "Connect"
+				):
 					all_datapacks_loaded.disconnect(caller)
 
+# Create a websocket and assign it to [member AP._socket]
 func _create_socket() -> void:
 	const BYTE_PER_MB := 1000000
 	_socket = WebSocketPeer.new()
 	_socket.inbound_buffer_size = websocket_inbuffer_mb*BYTE_PER_MB
 #endregion CONNECTION
 
+
 #region LOGGING TO FILE
 ## The current file being logged to.
 static var logging_file: FileAccess = null
+
+
 ## Opens the GodotAP logging file, if it isn't already open
 static func open_logger() -> void:
 	if not logging_file:
 		logging_file = FileAccess.open("user://ap/ap_log.log",FileAccess.WRITE)
+
+
 ## Closes the GodotAP logging file, if its open
 static func close_logger() -> void:
 	if logging_file:
 		logging_file.close()
 		logging_file = null
+
+
 # Logs a message to the GodotAP log
 static func _log(s: String) -> void:
 	if logging_file:
 		logging_file.store_line(s)
-		if OS.is_debug_build(): logging_file.flush() # Ensure logs are immediately flushed in case of crash
+		if OS.is_debug_build():
+			logging_file.flush() # Ensure logs are immediately flushed in case of crash
 	var msg: String = "[AP] %s" % s
 	print(msg)
 	if Archipelago:
 		Archipelago._logged_message.emit(msg)
+
+
 ## Logs a message to the GodotAP log
 static func log(s: Variant) -> void:
 	_log(str(s))
+
+
 ## Logs a warning to the GodotAP log and Godot warning console
 static func warn(s: Variant) -> void:
 	AP.log("[WARN] %s" % str(s))
 	push_warning(s)
+
+
 ## Logs an error to the GodotAP log and Godot error console
 static func error(s: Variant) -> void:
 	AP.log("[ERROR] %s" % str(s))
 	push_error(s)
 
+
 ## Logs a message to the GodotAP log, but only if AP_LOG_COMMUNICATION is true
 func comm_log(pref: String, s: Variant) -> void:
 	if not AP_LOG_COMMUNICATION: return
 	AP.log("[%s] %s" % [pref,str(s)])
+
+
 ## Logs a message to the GodotAP log, but only in a Debug build
 static func dblog(s: Variant) -> void:
 	if not OS.is_debug_build(): return
 	AP.log(s)
+
+
 ## Logs a warning to the GodotAP log and Godot warning console, but only in a Debug build
 static func dbwarn(s: Variant) -> void:
 	if not OS.is_debug_build(): return
 	AP.warn(s)
+
+
 ## Logs an error to the GodotAP log and Godot error console, but only in a Debug build
 static func dberror(s: Variant) -> void:
 	if not OS.is_debug_build(): return
 	AP.error(s)
 #endregion
 
+# Current state of the websocket connection
 var _socket_state: WebSocketPeer.State = WebSocketPeer.STATE_CLOSED
-func _poll() -> void: # Poll the websocket
+
+
+# Poll the websocket
+func _poll() -> void: 
 	while true:
 		await get_tree().process_frame
 		if status == APStatus.DISCONNECTED:
 			continue
+			
 		if status == APStatus.SOCKET_CONNECTING:
 			match _socket_state:
 				WebSocketPeer.STATE_OPEN: # Already connected, disconnect that connection
 					ap_disconnect()
 					_socket_state = _socket.get_ready_state()
+					
 				WebSocketPeer.STATE_CLOSED: # Start a new connection
 					var err: Error = _socket.connect_to_url(get_url())
 					if err:
-						AP.log("Connection to '%s' failed! Retrying (%d)" % [get_url(),_connect_attempts])
+						AP.log("Connection to '%s' failed! Retrying (%d)" % \
+								[get_url(),_connect_attempts])
 						_wss = not _wss
-						if _wss: _connect_attempts += 1
+						if _wss:
+							_connect_attempts += 1
 					elif output_console and not _connecting_part:
-						_connecting_part = output_console.add(BaseConsole.make_text("Connecting...","%s:%s %s" % [creds.ip,creds.port,creds.slot], ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
+						_connecting_part = output_console.add(
+								BaseConsole.make_text("Connecting...",
+										"%s:%s %s" % [creds.ip,creds.port,creds.slot],
+										ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 					_socket_state = _socket.get_ready_state()
+					
 				WebSocketPeer.STATE_CONNECTING: # Continue trying to make new connection
 					_socket.poll()
 					_socket_state = _socket.get_ready_state()
@@ -426,15 +603,20 @@ func _poll() -> void: # Poll the websocket
 								_connecting_part.tooltip_text += "\nFailed connecting too many times. Check your connection details, or '/reconnect' to try again."
 								_connecting_part = null
 						else:
-							AP.log("Connection to '%s' failed! Retrying (%d)" % [get_url(),_connect_attempts])
+							AP.log("Connection to '%s' failed! Retrying (%d)" % \
+									[get_url(),_connect_attempts])
 							_wss = not _wss
-							if _wss: _connect_attempts += 1
+							if _wss:
+								_connect_attempts += 1
+							
 				WebSocketPeer.STATE_CLOSING:
 					_socket.poll()
 					_socket_state = _socket.get_ready_state()
 			continue
+			
 		_socket.poll()
 		_socket_state = _socket.get_ready_state()
+		
 		match _socket_state:
 			WebSocketPeer.STATE_CLOSED: # Exited; handle reconnection, or concluding intentional disconnection
 				hang_clock.stop()
@@ -444,6 +626,7 @@ func _poll() -> void: # Poll the websocket
 				else:
 					AP.log("Accidental disconnection; reconnecting!")
 					ap_reconnect()
+					
 			WebSocketPeer.STATE_OPEN: # Running; handle communication
 				while _socket.get_available_packet_count():
 					var packet: PackedByteArray = _socket.get_packet()
@@ -453,17 +636,27 @@ func _poll() -> void: # Poll the websocket
 					for dict in json:
 						_handle_command(dict)
 
-var _printout_recieved_items: bool = false # Used by AP_PRINT_ITEMS_ON_CONNECT
-## Sends a command of the specified name, with the given dictionary as the command arguments, to the Archipelago server
+
+# Used by AP_PRINT_ITEMS_ON_CONNECT
+var _printout_recieved_items: bool = false
+
+
+## Sends a command with [param cmdname] as the command and [param args] as the arguments to the
+## Archipelago server.
 func send_command(cmdname: String, args: Dictionary) -> void:
 	args["cmd"] = cmdname
 	send_packet([args])
+
+
 ## Sends an array of dictionaries as a packet of commands to the server
 func send_packet(obj: Array) -> void:
 	var s := JSON.stringify(obj)
 	Archipelago.comm_log("SEND", s)
 	_socket.send_text(s)
-func _handle_command(json: Dictionary) -> void: # Handle an incoming packet from the server
+
+
+# Handle an incoming packet from the server
+func _handle_command(json: Dictionary) -> void: 
 	var command = json["cmd"]
 	comm_log("RECV", str(json))
 	match command:
@@ -477,16 +670,22 @@ func _handle_command(json: Dictionary) -> void: # Handle an incoming packet from
 			conn.gen_version = Version.from(json["generator_version"])
 			conn.seed_name = json["seed_name"]
 			handle_datapackage_checksums(json["datapackage_checksums"])
-			var args: Dictionary = {"name":creds.slot,"password":creds.pwd,"uuid":config.uuid,
-				"version":AP_VERSION._as_ap_dict(),"slot_data":true}
-			args["game"] = AP_GAME_NAME
-			args["tags"] = AP_GAME_TAGS
-			args["items_handling"] = AP_ITEM_HANDLING
+			var args: Dictionary = {
+				"name": creds.slot,
+				"password": creds.pwd,
+				"uuid": config.uuid,
+				"version": AP_VERSION._as_ap_dict(),
+				"slot_data": true,
+				"game": AP_GAME_NAME,
+				"tags": AP_GAME_TAGS,
+				"items_handling": AP_ITEM_HANDLING,
+			}
 			roominfo.emit(conn, json)
 			SignalChooser.new().register_multiple(
 				[all_datapacks_loaded, disconnected],
 				[send_command.bind("Connect",args), Util.nil])
 			_send_datapack_request()
+			
 		"ConnectionRefused":
 			var err_str := str(json["errors"])
 			if output_console and _connecting_part:
@@ -497,6 +696,7 @@ func _handle_command(json: Dictionary) -> void: # Handle an incoming packet from
 			connect_step.emit("ERR: %s" % err_str)
 			connectionrefused.emit(conn, json)
 			ap_disconnect()
+			
 		"Connected":
 			conn.player_id = json["slot"]
 			conn.team_id = json["team"]
@@ -549,22 +749,26 @@ func _handle_command(json: Dictionary) -> void: # Handle an incoming packet from
 
 			conn._load_locations()
 			connected.emit(conn, json)
+			
 		"PrintJSON":
 			_preparse_json(json)
 			var s: String = (output_console.printjson_command(json) if output_console
 				else BaseConsole.printjson_str(json["data"]))
 			AP.log("[PRINT] %s" % s)
 			printjson.emit(json, s)
+			
 		"DataPackage":
 			var packs = json["data"]["games"]
 			for game in packs.keys():
 				_handle_datapack(game, packs[game])
 			_send_datapack_request()
+			
 		"ReceivedItems":
 			while status != APStatus.PLAYING:
 				if status == APStatus.CONNECTED:
 					await status_updated
-				else: return
+				else: 
+					return
 			var idx: int = json["index"]
 			var items: Array[NetworkItem] = []
 			for obj in json["items"]:
@@ -587,6 +791,7 @@ func _handle_command(json: Dictionary) -> void: # Handle an incoming packet from
 				refr_items.make_read_only()
 				conn.received_items.assign(refr_items)
 				conn.refresh_items.emit(refr_items)
+				
 		"RoomUpdate":
 			for loc in json.get("checked_locations", []):
 				_remove_loc(loc)
@@ -595,6 +800,7 @@ func _handle_command(json: Dictionary) -> void: # Handle an incoming packet from
 				for plyr in json["players"]:
 					conn.players.append(NetworkPlayer.from(plyr))
 			conn.roomupdate.emit(json)
+			
 		"Bounced":
 			conn.bounce.emit(json)
 			var tags: Array = json.get("tags", [])
@@ -613,22 +819,35 @@ func _handle_command(json: Dictionary) -> void: # Handle an incoming packet from
 				var trap_name: String = json["data"].get("trap_name", "")
 				trap_name = TRAP_LINK_ALIASES.get(trap_name, trap_name)
 				conn.traplink.emit(source, trap_name, json)
+				
 		"LocationInfo":
 			conn._on_locinfo(json)
+			
 		"Retrieved":
 			conn._on_retrieve(json)
+			
 		"SetReply":
 			conn.setreply.emit(json)
+			
 		"InvalidPacket":
-			AP.log("[INVALID PACKET] Error with %s of command '%s' (%s)" % [json["type"], json.get("original_cmd", "?"), json["text"]])
+			AP.log("[INVALID PACKET] Error with %s of command '%s' (%s)" % [json["type"],
+					json.get("original_cmd", "?"),
+					json["text"]])
+			
 		_:
 			AP.log("[UNHANDLED PACKET TYPE] %s" % str(json))
 
-#region DATAPACKS
-var _datapack_cache: Dictionary # Local cache of DataPackages used when connecting
-var _datapack_pending: Array[String] = [] # List of DataPackages that are still being waited for
 
-## For each game (key) in the checksums dictionary, requests an update for its datapackage
+#region DATAPACKS
+# Local cache of DataPackages used when connecting
+var _datapack_cache: Dictionary 
+
+
+# List of DataPackages that are still being waited for
+var _datapack_pending: Array[String] = [] 
+
+
+## For each game (key) in the [param checksums] dictionary, requests an update for its datapackage
 ## if the locally stored checksum does not match the given value
 func handle_datapackage_checksums(checksums: Dictionary) -> void:
 	DirAccess.make_dir_recursive_absolute("user://ap/datapacks/") # Ensure the directory exists, for later
@@ -642,21 +861,33 @@ func handle_datapackage_checksums(checksums: Dictionary) -> void:
 			if FileAccess.file_exists("user://ap/datapacks/%s.json" % game.validate_filename()):
 				# cache file is valid
 				var cached: Dictionary = _datapack_cache[game]
-				if cached["checksum"] == checksums[game] and cached["fields"] == datapack_cached_fields:
+				if (
+					cached["checksum"] == checksums[game] 
+					and cached["fields"] == datapack_cached_fields
+				):
 					continue # already up-to-date, matching checksum
 
 		_datapack_pending.append(game)
 
+
 # Caches and stores to disk `data` as the DataCache file for `game`
 func _handle_datapack(game: String, data: Dictionary) -> void:
-	var data_file := FileAccess.open("user://ap/datapacks/%s.json" % game.validate_filename(), FileAccess.WRITE)
-	_datapack_cache[game] = {"checksum":data["checksum"],"fields":datapack_cached_fields.duplicate()}
+	var data_file := FileAccess.open(
+			"user://ap/datapacks/%s.json" % game.validate_filename(),
+			FileAccess.WRITE)
+	_datapack_cache[game] = {
+		"checksum": data["checksum"],
+		"fields": datapack_cached_fields.duplicate()
+	}
 	for key: String in data.keys():
 		if not key in datapack_cached_fields:
 			data.erase(key)
 	data_file.store_string(JSON.stringify(data, "\t" if READABLE_DATAPACK_FILES else ""))
 	_data_caches[game] = DataCache.from(data)
 	data_file.close()
+
+
+# Request the next required datapack in [member AP._datapack_pending].
 func _send_datapack_request() -> void:
 	if _datapack_pending:
 		var game = _datapack_pending.pop_front()
@@ -668,13 +899,22 @@ func _send_datapack_request() -> void:
 		connect_step.emit("All DataPackages fetched!")
 		_cache_datapacks()
 		all_datapacks_loaded.emit()
+
+
+# Write the datapack cache to disk.
 func _cache_datapacks() -> void:
 	var cachefile = FileAccess.open("user://ap/datapacks/cache.dat", FileAccess.WRITE)
 	cachefile.store_var(_datapack_cache, true)
 	cachefile.close()
 
-static var _data_caches: Dictionary[String, DataCache] = {} # DataPackage objects for each game
-## Returns a DataCache for the specified game. If it cannot be found, returns an empty (invalid) DataCache, which can still be used, albeit it will not have the desired data within.
+
+# [DataPackage] objects for each game.
+static var _data_caches: Dictionary[String, DataCache] = {} 
+
+
+## Returns a [DataCache] for the specified game.
+## If one cann't be found, returns an empty (invalid) [DataCache], which can still be used, but will
+## not have the desired data within.
 static func get_datacache(game: String) -> DataCache:
 	var ret: DataCache = _data_caches.get(game)
 	if ret: return ret
@@ -687,7 +927,9 @@ static func get_datacache(game: String) -> DataCache:
 	return ret
 #endregion DATAPACKS
 
+
 #region ITEMS
+# Handle a received item
 func _receive_item(index: int, item: NetworkItem) -> bool:
 	assert(item.dest_player_id == conn.player_id)
 	if conn._received_index(index):
@@ -745,16 +987,22 @@ func _receive_item(index: int, item: NetworkItem) -> bool:
 		if conn.received_items.size() < index+1:
 			conn.received_items.resize(index+1)
 		conn.received_items[index] = item
+
 	return true
 #endregion ITEMS
 
+
 #region LOCATIONS
+# Send a signal to remove a location from the world.
 func _remove_loc(loc_id: int) -> void:
 	if conn and not conn.slot_locations.get(loc_id, false):
 		conn.slot_locations[loc_id] = true
 		remove_location.emit(loc_id)
-## Will call `proc` when the specified location id is "removed" (i.e. collected, either by the player or the server)
-## If the location is already removed when you call this, `proc` will be called immediately.
+
+
+## Will call [param proc] when the location specified by [param loc_id] is "removed" 
+## (i.e. collected, either by the player or the server).
+## If the location is already removed when you call this, [param proc] will be called immediately.
 func on_removed_id(loc_id: int, proc: Callable) -> void:
 	if conn.slot_locations.get(loc_id, false):
 		proc.call()
@@ -762,10 +1010,14 @@ func on_removed_id(loc_id: int, proc: Callable) -> void:
 		remove_location.connect(func(id:int):
 			if id == loc_id:
 				proc.call())
-## Will call `proc` when the specified location name is "removed" (i.e. collected, either by the player or the server)
-## If the location is already removed when you call this, `proc` will be called immediately.
+
+
+## Will call [param proc] when the specified location name is "removed" 
+## (i.e. collected, either by the player or the server).
+## If the location is already removed when you call this, [param proc] will be called immediately.
 func on_removed(loc_name: String, proc: Callable) -> void:
 	on_removed_id(conn.get_gamedata_for_player(conn.player_id).get_loc_id(loc_name), proc)
+
 
 ## Call when a single location is collected and needs to be sent to the server.
 func collect_location(loc_id: int) -> void:
@@ -773,6 +1025,8 @@ func collect_location(loc_id: int) -> void:
 	_printout_recieved_items = false
 	send_command("LocationChecks", {"locations":[loc_id]})
 	_remove_loc(loc_id)
+
+
 ## Call when multiple locations are collected and need to be sent to the server at once.
 func collect_locations(locs: Array[int]) -> void:
 	if _is_nongame_client: return
@@ -782,12 +1036,18 @@ func collect_locations(locs: Array[int]) -> void:
 	for loc_id in locs:
 		_remove_loc(loc_id)
 
+
 ## Returns if the location exists in the slot or not.
 func location_exists(loc_id: int) -> bool:
 	return conn.slot_locations.has(loc_id)
-## Returns if the location was checked or not. `def` is returned if the location does not exist in the slot.
+
+
+## Returns if the location was checked or not. [param def] is returned if the location does not
+## exist in the slot.
 func location_checked(loc_id: int, def := false) -> bool:
 	return conn.slot_locations.get(loc_id, def)
+
+
 ## Returns a list of all location ids
 func location_list() -> Array[int]:
 	var arr: Array[int] = []
@@ -795,8 +1055,9 @@ func location_list() -> Array[int]:
 	return arr
 #endregion LOCATIONS
 
-## Try to reconnect to the current connection details, BUT if it detects errors in the details,
-## it will instead prompt the user to enter the details in the output console (if one is open).
+
+## Try to reconnect to the current connection details. If errors are detected in the details,
+## the user will instead be prompted to enter the details in the output console (if one is open).
 func ap_reconnect_to_save() -> void:
 	if creds.slot.is_empty() or creds.port.length() != 5:
 		if output_console:
@@ -805,27 +1066,36 @@ func ap_reconnect_to_save() -> void:
 				s += "Please reconnect to the room previously used by this save file!"
 			else:
 				s += "Connect to a room when ready."
-			output_console.add(BaseConsole.make_text(s, "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
+			output_console.add(BaseConsole.make_text(
+					s,
+					"",
+					ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 	else:
 		ap_reconnect()
+
 
 func _exit_tree():
 	if status != APStatus.DISCONNECTED:
 		ap_disconnect()
 
+
 func _notification(what):
 	if what == NOTIFICATION_PREDELETE:
 		AP.close_logger()
 
-#region CONSOLE
 
-var output_console_container: ConsoleContainer = null ## Container for the current output console
+#region CONSOLE
+## Container for the current output console
+var output_console_container: ConsoleContainer = null 
+
+
 ## The currently attached GodotAP console, if one exists.
 var output_console: BaseConsole :
 	get: return cmd_manager.console
 	set(val): cmd_manager.console = val
 
-## Loads a PackedScene as the active console. This becomes the active scene in the passed SceneTree.
+
+## Loads [param console] as the active console and makes it the active scene in [param tree].
 func load_packed_console_as_scene(tree: SceneTree, console: PackedScene) -> bool:
 	if output_console: return false
 	if not Util.for_all_nodes(console.instantiate(), func(node): return node is ConsoleContainer):
@@ -836,7 +1106,10 @@ func load_packed_console_as_scene(tree: SceneTree, console: PackedScene) -> bool
 	assert(tree.current_scene)
 	load_console(tree.current_scene, false)
 	return true
-## Loads a Node as the active console. The window this node is in will be considered the console window.
+
+
+## Loads [param console_scene] as the active console.
+## The window this node is in will be considered the console window.
 func load_console(console_scene: Node, as_child := true) -> bool:
 	if output_console: return false
 	if console_scene is ConsoleContainer:
@@ -858,34 +1131,48 @@ func load_console(console_scene: Node, as_child := true) -> bool:
 		output_console_container.typing_bar.cmd_manager = cmd_manager
 		on_attach_console.emit())
 	return true
+
+
 ## Opens a default Archipelago text console popup
 func open_console() -> void:
 	if output_console: return
 	load_console(load("res://godot_ap/ui/ap_console_window.tscn").instantiate())
+
+
 ## Closes the currently attached console
 func close_console() -> void:
 	if output_console:
 		output_console.close()
 		output_console = null
-
 #endregion CONSOLE
 
-## The CommandManager for console commands. New commands can be registered as you like.
+
+## The [CommandManager] for console commands. New commands can be registered as you like.
 var cmd_manager: CommandManager = CommandManager.new()
-## Resets the CommandManager used by the archipelago console
+
+
+## Resets the [CommandManager] used by the archipelago console
 func init_command_manager(can_connect: bool, server_autofills: bool = true):
 	cmd_manager.reset()
 	cmd_manager.register_default(func(mgr: CommandManager, msg: String):
 		if msg[0] == "/":
-			mgr.console.add(BaseConsole.make_text("Unknown command '%s' - use '/help' to see commands" % msg.split(" ", true, 1)[0], "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
+			mgr.console.add(BaseConsole.make_text(
+					"Unknown command '%s' - use '/help' to see commands" % msg.split(" ", true, 1)[0],
+					"",
+					ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 		else:
 			if _ensure_connected(mgr.console):
 				send_command("Say", {"text":msg}))
+	
 	if can_connect:
 		cmd_manager.register_command(ConsoleCommand.new("/connect")
 			.add_help("port", "Connects to a new port, with the same ip/slot/password.")
-			.add_help("ip[:port]", "Connects to a new ip+[optional] port, with the same slot/password. (if port omitted, uses 38281)")
-			.add_help("ip[:port] slot [pwd]", "Connects to a new ip+port, with a new slot and [optional] password. (if port omitted, uses 38281)")
+			.add_help(
+					"ip[:port]",
+					"Connects to a new ip+[optional] port, with the same slot/password. (if port omitted, uses 38281)")
+			.add_help(
+					"ip[:port] slot [pwd]",
+					"Connects to a new ip+port, with a new slot and [optional] password. (if port omitted, uses 38281)")
 			.set_call(func(mgr: CommandManager, cmd: ConsoleCommand, msg: String):
 				var command_args = msg.split(" ", true, 3)
 				if command_args.size() == 2:
@@ -904,53 +1191,72 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 					elif ipport.size() == 1:
 						ipport.append("38281")
 					ap_connect(ipport[0],ipport[1],command_args[2],command_args[3])))
+		
 		cmd_manager.register_command(ConsoleCommand.new("/reconnect")
 			.add_help("", "Refreshes the connection to the Archipelago server")
-			.set_call(func(_mgr: CommandManager, _cmd: ConsoleCommand, _msg: String): ap_reconnect()))
+			.set_call(func(
+					_mgr: CommandManager,
+					_cmd: ConsoleCommand,
+					_msg: String):
+						ap_reconnect()))
+		
 		cmd_manager.register_command(ConsoleCommand.new("/disconnect")
 			.add_help_cond("", "Kills the connection to the Archipelago server", is_ap_connected)
-			.set_call(func(_mgr: CommandManager, _cmd: ConsoleCommand, _msg: String): ap_disconnect()))
+			.set_call(func(
+					_mgr: CommandManager,
+					_cmd: ConsoleCommand,
+					_msg: String):
+						ap_disconnect()))
+	
 	cmd_manager.register_command(ConsoleCommand.new("/locations")
-		.add_help_cond("[filter]", "Lists all locations (optionally matching a filter) for the current slot's game.", is_ap_connected)
+		.add_help_cond(
+				"[filter]",
+				"Lists all locations (optionally matching a filter) for the current slot's game.",
+				is_ap_connected)
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, msg: String):
 			if not _ensure_connected(mgr.console): return
 			var filt := msg.substr(11)
 			var data: DataCache = conn.get_gamedata_for_player()
-
+			
 			var grid := GridContainer.new()
 			grid.columns = 2
 			grid.add_theme_constant_override(&"h_separation", 80)
-
+			
 			var title := "LOCATIONS"
 			if filt: title += " (%s)" % filt
-			var folder := BaseConsole.make_foldable("[ %s ]" % title, msg, ComplexColor.as_special(SpecialColor.UI_MESSAGE))
+			var folder := BaseConsole.make_foldable(
+					"[ %s ]" % title,
+					msg,
+					ComplexColor.as_special(SpecialColor.UI_MESSAGE))
 			mgr.console.add(folder)
 			folder.add(grid)
 			folder.fold(false)
-
+			
 			var h1 := BaseConsole.make_text("Location Name:")
 			grid.add_child(h1)
 			if filt:
 				h1.tooltip_text = "Filter: " + filt
 			grid.add_child(BaseConsole.make_text("Status:"))
-
+			
 			var ids: Array = data.location_name_to_id.values()
 			var _index_dict := {}
 			for q in ids.size():
 				_index_dict[ids[q]] = q
 			ids.sort_custom(func(a,b):
 				return _index_dict[b] > _index_dict[a])
-
+			
 			for lid in ids:
 				var loc_name = data.get_loc_name(lid)
 				if not filt or (filt.to_lower() in loc_name.to_lower()):
 					var loc_status := find_hint_status(lid, NetworkHint.Status.NOT_FOUND)
-					var color := ComplexColor.as_rich(NetworkHint.status_colors.get(loc_status, RichColor.RED))
+					var color := ComplexColor.as_rich(
+							NetworkHint.status_colors.get(loc_status, RichColor.RED))
 					var stat_name: String = NetworkHint.status_names.get(loc_status, "Not Found")
 					grid.add_child(BaseConsole.make_text(loc_name, "Location %d" % lid, color))
 					grid.add_child(BaseConsole.make_text(stat_name, "", color))
 			mgr.console.add_header_spacing()
 			))
+	
 	cmd_manager.register_command(ConsoleCommand.new("/items")
 		.add_help_cond("[filter]", "Lists all items (optionally matching a filter) for the current slot's game.", is_ap_connected)
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, msg: String):
@@ -999,6 +1305,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 					if flag_options:
 						found_second_column = true
 						break
+			
 			var filt_ttip := "Filter: " + filt
 			if found_any:
 				grid.columns = 2 if found_second_column else 1
@@ -1016,7 +1323,11 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 							for flags in flag_options.keys():
 								var c1 := BaseConsole.make_item(iid, flags, data)
 								grid.add_child(c1)
-								grid.add_child(BaseConsole.make_text("x%d" % flag_options[flags], "", ComplexColor.as_rich(c1.rich_color)))
+								grid.add_child(
+										BaseConsole.make_text(
+												"x%d" % flag_options[flags],
+												"",
+												ComplexColor.as_rich(c1.rich_color)))
 						else:
 							grid.add_child(BaseConsole.make_text(itm_name, "Item %d" % iid))
 							if found_second_column:
@@ -1027,6 +1338,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 					filt_ttip, ComplexColor.as_rich(AP.RichColor.SALMON)))
 			mgr.console.add_header_spacing()
 			))
+			
 	if server_autofills: # Autofill for some AP commands
 		cmd_manager.register_command(ConsoleCommand.new("!hint_location")
 			.set_autofill(_autofill_locs)
@@ -1049,6 +1361,7 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 			.add_disable(is_not_connected))
 		cmd_manager.register_command(ConsoleCommand.new("!players")
 			.add_disable(is_not_connected))
+			
 	cmd_manager.setup_basic_commands()
 	if OS.is_debug_build():
 		cmd_manager.register_command(ConsoleCommand.new("/send").debug()
@@ -1064,22 +1377,37 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 						var loc_name := data.get_loc_name(loc)
 						if loc_name.strip_edges().to_lower() == command_args[1].strip_edges().to_lower():
 							if conn.slot_locations[loc]:
-								mgr.console.add(BaseConsole.make_text("Location already sent!", "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
+								mgr.console.add(BaseConsole.make_text(
+										"Location already sent!",
+										"",
+										ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 							else:
-								mgr.console.add(BaseConsole.make_text("Sending location '%s'!" % loc_name, "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
+								mgr.console.add(BaseConsole.make_text(
+										"Sending location '%s'!" % loc_name,
+										"",
+										ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 								collect_location(loc)
 							return
-					mgr.console.add(BaseConsole.make_text("Location '%s' not found! Check spelling?" % command_args[1].strip_edges(), "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
+					mgr.console.add(BaseConsole.make_text(
+							"Location '%s' not found! Check spelling?" % command_args[1].strip_edges(),
+							"",
+							ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 				else: cmd.output_usage(mgr.console)))
+		
 		cmd_manager.register_command(ConsoleCommand.new("/lock_info").debug()
 			.add_help("", "Prints the connection lock info")
 			.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
-				mgr.console.add(BaseConsole.make_text("%s" % (str(aplock) if aplock else "No Lock Active"), "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
+				mgr.console.add(BaseConsole.make_text(
+						"%s" % (str(aplock) if aplock else "No Lock Active"),
+						"",
+						ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
+				
 		cmd_manager.register_command(ConsoleCommand.new("/unlock_connection").debug()
 			.add_help("", "Unlocks the connection lock, so that any valid slot can be connected to (instead of only the slot previously connected to)")
 			.set_call(func(_mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
 				if aplock:
 					aplock.unlock()))
+					
 		cmd_manager.register_command(ConsoleCommand.new("/set_tag").debug()
 			.add_help("tag [bool]", "Sets a tag for the current connection")
 			.set_autofill(func(msg: String):
@@ -1119,25 +1447,39 @@ func init_command_manager(can_connect: bool, server_autofills: bool = true):
 						cmd.output_usage(mgr.console)
 						return
 				set_tag(tag, state)
-				mgr.console.add(BaseConsole.make_text("Set tag '%s' to %s" % [args[1],state], "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
+				mgr.console.add(BaseConsole.make_text(
+						"Set tag '%s' to %s" % [args[1],state],
+						"",
+						ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
+				
 		cmd_manager.register_command(ConsoleCommand.new("/tags").debug()
 			.add_help("", "Prints out your connection tags")
 			.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
-				mgr.console.add(BaseConsole.make_text(str(AP_GAME_TAGS), "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
+					mgr.console.add(BaseConsole.make_text(str(AP_GAME_TAGS),
+					"",
+					ComplexColor.as_special(SpecialColor.UI_MESSAGE)))))
+				
 		cmd_manager.register_command(ConsoleCommand.new("/slot_data").debug()
 			.add_help("", "Prints slot_data")
 			.add_disable(is_not_connected)
 			.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
-				var folder := BaseConsole.make_foldable("[ SLOT_DATA ]", "/slot_data", ComplexColor.as_special(SpecialColor.UI_MESSAGE))
-				mgr.console.add(folder)
-				folder.add(BaseConsole.make_indented_block(JSON.stringify(Archipelago.conn.slot_data, "\t"), 25))
-				folder.fold(false)
-				))
+					var folder := BaseConsole.make_foldable(
+							"[ SLOT_DATA ]", "/slot_data",
+							ComplexColor.as_special(SpecialColor.UI_MESSAGE))
+					mgr.console.add(folder)
+					folder.add(BaseConsole.make_indented_block(
+							JSON.stringify(Archipelago.conn.slot_data, "\t"), 
+							25))
+					folder.fold(false)
+					))
 		cmd_manager.setup_debug_commands()
+
 
 func _init():
 	init_command_manager(true)
 	_poll.call_deferred()
+
+
 func _ready():
 	_update_tags()
 	if AP_AUTO_OPEN_CONSOLE:
@@ -1153,15 +1495,22 @@ func _ready():
 		config = APConfigManager.new()
 		add_child(config)
 	# 'save_manager' can be null
+
+
 ## Item Classification bits
 enum ItemClassification {
+	## Filler item
 	FILLER = 0b000,
+	## Progression item
 	PROG = 0b001,
+	## Useful item
 	USEFUL = 0b010,
+	## Trap item
 	TRAP = 0b100
 }
 
-## Converts a set of ItemClassification flags to a 'SpecialColor'
+
+## Converts a set of [ItemClassification] flags to a [SpecialColor]
 static func get_item_class_color(flags: int) -> SpecialColor:
 	if flags & ItemClassification.PROG:
 		if Archipelago.AP_ENABLE_PROGUSEFUL and (flags & ItemClassification.USEFUL):
@@ -1173,7 +1522,9 @@ static func get_item_class_color(flags: int) -> SpecialColor:
 	elif flags & ItemClassification.USEFUL:
 		return SpecialColor.ITEM_USEFUL
 	return SpecialColor.ITEM
-## Returns the string name representing the combined item classifications flags
+
+
+## Returns the string name representing the combined [ItemClassification] flags
 static func get_item_classification(flags: int) -> String:
 	match flags:
 		ItemClassification.PROG:
@@ -1193,7 +1544,11 @@ static func get_item_classification(flags: int) -> String:
 					s += get_item_classification(1<<q)
 			return s
 
+
+# no-op
 func _cmd_nil(_msg: String): pass
+
+
 func _autofill_locs(msg: String) -> Array[String]:
 	if not conn: return []
 	var args = msg.split(" ", true, 1)
@@ -1221,6 +1576,8 @@ func _autofill_locs(msg: String) -> Array[String]:
 	for q in locs.size():
 		locs[q] = "%s %s" % [args[0],locs[q]]
 	return locs
+
+
 func _autofill_items(msg: String) -> Array[String]:
 	if not conn: return []
 	var args = msg.split(" ", true, 1)
@@ -1243,8 +1600,11 @@ func _autofill_items(msg: String) -> Array[String]:
 		itms[q] = "%s %s" % [args[0],itms[q]]
 	return itms
 
+
 # If the current client is `non-game`, i.e. a `TextOnly`, `Tracker`, or `HintGame` tagged client which cannot send locations.
 var _is_nongame_client := false
+
+
 func _update_tags() -> void:
 	if status == APStatus.PLAYING:
 		send_command("ConnectUpdate", {"tags":AP_GAME_TAGS})
@@ -1254,6 +1614,8 @@ func _update_tags() -> void:
 			_is_nongame_client = true
 			break
 	on_tag_change.emit()
+
+
 ## Sets a given Archipelago tag (on or off)
 func set_tag(tag: String, state := true) -> void:
 	if tag.is_empty(): return
@@ -1267,15 +1629,22 @@ func set_tag(tag: String, state := true) -> void:
 	if state:
 		AP_GAME_TAGS.append(tag)
 		_update_tags()
+
+
 ## Checks if a given tag is active
 func has_tag(tag: String) -> bool:
 	return tag in AP_GAME_TAGS
+
+
 ## Sets the Archipelago connection tags (overwriting all existing tags)
 func set_tags(tags: Array[String]) -> void:
 	if AP_GAME_TAGS != tags:
 		AP_GAME_TAGS.assign(tags)
 		_update_tags()
-## Sets the Archipelago connection tags (overwrites tags except supported tags 'DeathLink' / 'TrapLink')
+
+
+## Sets the Archipelago connection tags 
+## (overwrites tags except supported tags [code]DeathLink[/code] / [code]TrapLink[/code])
 func set_misc_tags(tags: Array[String]) -> void:
 	var supported_tags: Array[String] = [get_deathlink_tag(), "TrapLink"]
 	tags = tags.duplicate()
@@ -1286,11 +1655,13 @@ func set_misc_tags(tags: Array[String]) -> void:
 		else: tags.erase(tag)
 	set_tags(tags)
 
+
 func _ensure_connected(console: BaseConsole) -> bool:
 	if status == APStatus.PLAYING:
 		return true
 	console.add(BaseConsole.make_text("Not connected to Archipelago! Please connect first!", "", ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 	return false
+
 
 ## Changes this connection's DeathLink group
 ## Will only send/receive deaths with other clients in the same group
@@ -1302,39 +1673,59 @@ func set_deathlink_group(group: String) -> void:
 	deathlink_group = group
 	if deathlink:
 		set_deathlink(true)
+
+
 ## Returns the current DeathLink group name
 ## Will only send/receive deaths with other clients in the same group
 func get_deathlink_group() -> String:
 	return deathlink_group
+
+
 ## Returns the tag being used for DeathLink (including DeathLink group support)
 func get_deathlink_tag() -> String:
 	return "DeathLink" + deathlink_group
-## Turn 'DeathLink' on or off
+
+
+## Turn DeathLink on or off
 func set_deathlink(state: bool) -> void:
 	set_tag(get_deathlink_tag(), state)
-## Check if 'DeathLink' is on
+
+
+## Check if DeathLink is on
 func is_deathlink() -> bool:
 	return has_tag(get_deathlink_tag())
 
-## Turn 'TrapLink' on or off
+
+## Turn TrapLink on or off
 func set_traplink(state: bool) -> void:
 	set_tag("TrapLink", state)
-## Check if 'TrapLink' is on
+
+
+## Check if TrapLink is on
 func is_traplink() -> bool:
 	return has_tag("TrapLink")
 
+
 ## Archipelago client statuses
 enum ClientStatus {
-	CLIENT_UNKNOWN = 0, ## error value
-	CLIENT_CONNECTED = 5, ## at least one client has connected to this slot
-	CLIENT_READY = 10, ## this slot has indicated it is 'ready'
-	CLIENT_PLAYING = 20, ## this slot has begun playing
-	CLIENT_GOAL = 30 ## this slot has won
+	## Error value.
+	CLIENT_UNKNOWN = 0, 
+	## At least one client has connected to this slot.
+	CLIENT_CONNECTED = 5,
+	## This slot has indicated it is ready.
+	CLIENT_READY = 10,
+	## This slot has begun playing
+	CLIENT_PLAYING = 20, 
+	## This slot has won
+	CLIENT_GOAL = 30, 
 }
+
+
 ## Set the current Archipelago status.
-## Set to 'CLIENT_GOAL' when the player has 'won'.
+## Set to [code CLIENT_GOAL] when the player has won.
 func set_client_status(stat: ClientStatus) -> void:
 	send_command("StatusUpdate", {"status": stat})
+
 
 ## Gets the status of the specified hint.
 func find_hint_status(loc_id: int, default := NetworkHint.Status.UNSPECIFIED) -> NetworkHint.Status:
@@ -1345,6 +1736,7 @@ func find_hint_status(loc_id: int, default := NetworkHint.Status.UNSPECIFIED) ->
 			hint.item.loc_id == loc_id:
 			return hint.status
 	return default
+
 
 # Used to override incoming packets from the Archipelago server.
 func _preparse_json(json: Dictionary) -> void:

--- a/godot_ap/autoloads/archipelago.gd
+++ b/godot_ap/autoloads/archipelago.gd
@@ -160,7 +160,7 @@ class ComplexColor:
 		return ret
 
 
-	## Get the color represented by this complex color for the proviced [param node].
+	## Get the color represented by this complex color for the provided [param node].
 	## [param node] is needed, as the representation can depend on the node's [Theme].
 	func calculate(node: Control) -> Color:
 		if rich:
@@ -1645,7 +1645,7 @@ func _ensure_connected(console: BaseConsole) -> bool:
 	return false
 
 
-## Changes this connection's DeathLink group.
+## Changes this connection's DeathLink group name.
 ## Will only send/receive deaths with other clients in the same group.
 func set_deathlink_group(group: String) -> void:
 	if group == deathlink_group:

--- a/godot_ap/autoloads/archipelago.gd
+++ b/godot_ap/autoloads/archipelago.gd
@@ -553,15 +553,16 @@ func _poll() -> void:
 				WebSocketPeer.STATE_CLOSED: # Start a new connection
 					var err: Error = _socket.connect_to_url(get_url())
 					if err:
-						AP.log("Connection to '%s' failed! Retrying (%d)" % \
-								[get_url(),_connect_attempts])
+						AP.log(
+								"Connection to '%s' failed! Retrying (%d)" % \
+								[get_url(), _connect_attempts])
 						_wss = not _wss
 						if _wss:
 							_connect_attempts += 1
 					elif output_console and not _connecting_part:
 						_connecting_part = output_console.add(
 								BaseConsole.make_text("Connecting...",
-										"%s:%s %s" % [creds.ip,creds.port,creds.slot],
+										"%s:%s %s" % [creds.ip, creds.port, creds.slot],
 										ComplexColor.as_special(SpecialColor.UI_MESSAGE)))
 					_socket_state = _socket.get_ready_state()
 					
@@ -578,11 +579,13 @@ func _poll() -> void:
 							AP.log("Connection to '%s' failed too much! Giving up!" % get_url())
 							if output_console and _connecting_part:
 								_connecting_part.text = "Connection Failed!"
-								_connecting_part.tooltip_text += "\nFailed connecting too many times. Check your connection details, or '/reconnect' to try again."
+								_connecting_part.tooltip_text += "\nFailed connecting too many " + \
+										"times. Check your connection details, " + \
+										"or '/reconnect' to try again."
 								_connecting_part = null
 						else:
 							AP.log("Connection to '%s' failed! Retrying (%d)" % \
-									[get_url(),_connect_attempts])
+									[get_url(), _connect_attempts])
 							_wss = not _wss
 							if _wss:
 								_connect_attempts += 1
@@ -897,7 +900,8 @@ static func get_datacache(game: String) -> DataCache:
 	if ret:
 		return ret
 	
-	var data_file := FileAccess.open("user://ap/datapacks/%s.json" % game.validate_filename(), FileAccess.READ)
+	var data_file := FileAccess.open("user://ap/datapacks/%s.json" % game.validate_filename(),
+			FileAccess.READ)
 	if not data_file:
 		return DataCache.new()
 	ret = DataCache.from_file(data_file)

--- a/godot_ap/managers/command_manager.gd
+++ b/godot_ap/managers/command_manager.gd
@@ -12,6 +12,7 @@ var _commands: Array[ConsoleCommand]
 var _commands_by_name: Dictionary[String, ConsoleCommand]
 
 ## Controls if debug commands should be hidden.
+## Cannot be modified in non-debug builds.
 var debug_hidden := true :
 	set(val):
 		if not OS.is_debug_build():
@@ -98,7 +99,7 @@ func call_cmd(msg: String) -> void:
 		return
 	var cmd := get_command(msg.split(" ", true, 1)[0])
 	if cmd and cmd.call_proc:
-		if cmd.is_disabled():
+		if cmd.is_disabled() or (cmd.is_debug() and debug_disabled()):
 			console.add(BaseConsole.make_text("Command '%s' is disabled!" % cmd.text, "",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 		else:
@@ -122,7 +123,7 @@ func get_command(cmdname: String) -> ConsoleCommand:
 
 # Check if [param cmd] is enabled.
 static func _cmd_is_enabled(cmd: ConsoleCommand) -> bool:
-	return not cmd.is_disabled()
+	return not (cmd.is_disabled() or (cmd.is_debug() and debug_disabled()))
 
 
 # Check if [param cmd] is debug-only.

--- a/godot_ap/managers/command_manager.gd
+++ b/godot_ap/managers/command_manager.gd
@@ -99,7 +99,7 @@ func call_cmd(msg: String) -> void:
 		return
 	var cmd := get_command(msg.split(" ", true, 1)[0])
 	if cmd and cmd.call_proc:
-		if cmd.is_disabled() or (cmd.is_debug() and debug_disabled()):
+		if cmd.is_disabled() or (cmd.is_debug() and cmd.debug_disabled()):
 			console.add(BaseConsole.make_text("Command '%s' is disabled!" % cmd.text, "",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 		else:
@@ -123,7 +123,7 @@ func get_command(cmdname: String) -> ConsoleCommand:
 
 # Check if [param cmd] is enabled.
 static func _cmd_is_enabled(cmd: ConsoleCommand) -> bool:
-	return not (cmd.is_disabled() or (cmd.is_debug() and debug_disabled()))
+	return not (cmd.is_disabled() or (cmd.is_debug() and cmd.debug_disabled()))
 
 
 # Check if [param cmd] is debug-only.

--- a/godot_ap/managers/command_manager.gd
+++ b/godot_ap/managers/command_manager.gd
@@ -47,12 +47,12 @@ func debug_disabled() -> bool:
 	return debug_hidden
 
 
-## Autofill the arguments to a command message, up to the number of arguments specified in
+## Get the autofilled parameters for a command message, up to the number of arguments specified in
 ## [param capacity].
 func autofill(msg: String, capacity := 5) -> Array[String]:
 	if msg.is_empty():
 		return []
-	var split_msg := msg.split(" ",true,1)
+	var split_msg := msg.split(" ", true, 1)
 	var cmd: ConsoleCommand = _commands_by_name.get(split_msg[0])
 	var ret: Array[String] = []
 

--- a/godot_ap/managers/command_manager.gd
+++ b/godot_ap/managers/command_manager.gd
@@ -48,8 +48,9 @@ func debug_disabled() -> bool:
 	return debug_hidden
 
 
-## Get the autofilled parameters for a command message, up to the number of arguments specified in
-## [param capacity].
+## Get the autofilled arguments for a command message, up to the number of arguments specified in
+## [param capacity]. If [param capacity] is [code]0[/code], all available autofilled arguments will
+## be returned.
 func autofill(msg: String, capacity := 5) -> Array[String]:
 	if msg.is_empty():
 		return []

--- a/godot_ap/managers/command_manager.gd
+++ b/godot_ap/managers/command_manager.gd
@@ -1,19 +1,39 @@
-class_name CommandManager extends Node
+class_name CommandManager 
+extends Node
+## Manages available commands for an archipelago session
 
+## Emits a signal when [member debug_hidden] is changed.
 signal debug_toggled(disabled: bool)
 
+# The commands currently available to use.
 var _commands: Array[ConsoleCommand]
+
+# Commands currently available to use, indexed by name.
 var _commands_by_name: Dictionary[String, ConsoleCommand]
+
+## Controls if debug commands should be hidden.
 var debug_hidden := true :
 	set(val):
-		if not OS.is_debug_build(): return
-		if debug_hidden == val: return
+		if not OS.is_debug_build():
+			return
+		if debug_hidden == val:
+			return
 		debug_hidden = val
 		debug_toggled.emit()
-var default_procs: Array[Callable] ## [(CommandManager,String)->void]
 
+## Contains an array of [Callable]s to be called when no [ConsoleCommand] is registered for a
+## submitted command message.
+## [br]
+## Elements should take a [CommandManager] for the first parameter and a [String] for the second.
+## Returned values will be ignored.
+var default_procs: Array[Callable] 
+
+## The console to output to.
 var console: BaseConsole = null
 
+
+## Reset the command manager. Clears registered commands, [member default_procs], and sets
+## [member debug_hidden] to [code]true[/code].
 func reset() -> void:
 	_commands.clear()
 	_commands_by_name.clear()
@@ -21,40 +41,68 @@ func reset() -> void:
 	default_procs.clear()
 	#does NOT clear console reference
 
+
+## Returns [code]true[/code] if debug commands are being hidden, and false if they aren't.
 func debug_disabled() -> bool:
 	return debug_hidden
+
+
+## Autofill the arguments to a command message, up to the number of arguments specified in
+## [param capacity].
 func autofill(msg: String, capacity := 5) -> Array[String]:
-	if msg.is_empty(): return []
+	if msg.is_empty():
+		return []
 	var split_msg := msg.split(" ",true,1)
 	var cmd: ConsoleCommand = _commands_by_name.get(split_msg[0])
 	var ret: Array[String] = []
+
 	if cmd and not cmd.is_disabled() and cmd.autofill_proc:
 		ret.assign(cmd.autofill_proc.call(msg))
 	elif split_msg.size() < 2:
 		for iter_cmd in _commands:
-			if iter_cmd.is_disabled(): continue
-			if debug_hidden and iter_cmd.is_debug(): continue
-			if iter_cmd.text.begins_with(msg.to_lower()):
+			if iter_cmd.is_disabled():
+				continue
+			elif debug_hidden and iter_cmd.is_debug():
+				continue
+			elif iter_cmd.text.begins_with(msg.to_lower()):
 				ret.append(iter_cmd.text+" ")
+				
 	if capacity > 0 and ret.size() > capacity:
 		ret.resize(capacity)
+
 	return ret
 
+
+## Register a [ConsoleCommand].
 func register_command(cmd: ConsoleCommand) -> void:
 	cmd.text = cmd.text.to_lower() # Enforce all-lower for insensitive comparisons
 	_commands.append(cmd)
 	_commands_by_name[cmd.text] = cmd
 	if cmd.is_debug() and debug_hidden and not cmd.text == "/debug":
 		cmd.disabled_procs.append(debug_disabled)
+
+
+## Register a [Callable] to be used when no [ConsoleCommand] is found for a given command.
+## See also [member default_procs].
+## [br]
+## [param proc] should take [CommandManager] for the first parameter and a [String] for the second.
+## The second parameter will contain the message to be handled.
 func register_default(proc: Callable) -> void:
 	default_procs.append(proc)
 
+
+## Call the command for a given non-empty message. If none is found, the message is passed to all
+## registered [Callable]s in [member default_procs].
 func call_cmd(msg: String) -> void:
-	if msg.is_empty(): return
+	if msg.is_empty():
+		return
 	var cmd := get_command(msg.split(" ", true, 1)[0])
 	if cmd and cmd.call_proc:
 		if cmd.is_disabled():
-			console.add(BaseConsole.make_text("Command '%s' is disabled!" % cmd.text, "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			console.add(BaseConsole.make_text(
+					"Command '%s' is disabled!" % cmd.text,
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 		else:
 			cmd.call_proc.call(self, cmd, msg)
 	else:
@@ -62,21 +110,42 @@ func call_cmd(msg: String) -> void:
 			proc.call(self, msg)
 
 
+## Get the registered [ConsoleCommand]s.
+## [br]
+## [b]Do not mutate the returned array[/b]
 func get_commands() -> Array[ConsoleCommand]: # don't mutate the return
 	return _commands
+
+
+## Get the [ConsoleCommand] registered to [param cmdname].
 func get_command(cmdname: String) -> ConsoleCommand:
 	return _commands_by_name.get(cmdname.to_lower())
 
+
+# Check if [param cmd] is enabled.
 static func _cmd_is_enabled(cmd: ConsoleCommand) -> bool:
 	return not cmd.is_disabled()
+
+
+# Check if [param cmd] is debug-only.
 static func _cmd_is_debug(cmd: ConsoleCommand) -> bool:
 	return cmd.is_debug()
 
+
+## Get an array of all the enabled commands.
 func get_enabled_commands() -> Array[ConsoleCommand]:
 	return _commands.filter(CommandManager._cmd_is_enabled)
+
+
+## Get an array of all the debug-only commands.
 func get_debug_commands() -> Array[ConsoleCommand]:
 	return _commands.filter(CommandManager._cmd_is_debug)
 
+
+## Set up the basic [ConsoleCommand]s that will always be available.
+## [br]
+## Currently this sets up [code]/help[/code] for displaying available commands, [code]/cls[/code] 
+## for clearing the console, and [code]/clr_hist[/code] for clearing the command history.
 func setup_basic_commands() -> void:
 	register_command(ConsoleCommand.new("/help")
 		.add_help("", "Displays all currently available commands")
@@ -84,7 +153,8 @@ func setup_basic_commands() -> void:
 			mgr.console.add_header_spacing()
 			var folder := BaseConsole.make_foldable("[ COMMAND HELP ]",
 				"Commands shown may vary based on various conditions, such as if you are" +
-				" connected to an Archipelago server or not.", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE))
+				" connected to an Archipelago server or not.",
+				AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE))
 			mgr.console.add(folder)
 			folder.add(mgr.console.make_header_spacing())
 			for cmd in mgr.get_commands().filter(func(cmd):
@@ -92,31 +162,50 @@ func setup_basic_commands() -> void:
 				cmd.output_helptext(mgr.console, folder)
 			mgr.console.add_header_spacing()
 			folder.fold(false)))
+	
 	register_command(ConsoleCommand.new("/cls")
 		.add_help("", "Clears the console")
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
 			mgr.console.clear()))
+	
 	register_command(ConsoleCommand.new("/clr_hist")
 		.add_help("", "Clears the command history")
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
 			mgr.console.window.typing_bar.history_clear()))
+
+
+## Set up the [ConsoleCommand]s that will only be available when debug mode is enabled.
+## [br]
+## If [method OS.is_debug_build] returns false, no commands will be set up.
 func setup_debug_commands() -> void:
-	if not OS.is_debug_build(): return
+	if not OS.is_debug_build():
+		return
+
 	register_command(ConsoleCommand.new("/db_help").debug()
 		.add_help("", "Displays this message")
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
 			mgr.console.add_header_spacing()
-			mgr.console.add(BaseConsole.make_text("Debug Help:", "", AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+			mgr.console.add(BaseConsole.make_text(
+					"Debug Help:",
+					"",
+					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			for cmd in mgr.get_commands().filter(func(cmd):
 				return not cmd.is_disabled() and cmd.is_debug()):
 				cmd.output_helptext(mgr.console)
 			mgr.console.add_header_spacing()))
+			
 	register_command(ConsoleCommand.new("/debug").debug()
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
 			debug_hidden = not debug_hidden
 			mgr.console.add_header_spacing()
 			if debug_hidden:
-				mgr.console.add(BaseConsole.make_text("Debug mode disabled","",AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+				mgr.console.add(BaseConsole.make_text(
+						"Debug mode disabled",
+						"",
+						AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			else:
-				mgr.console.add(BaseConsole.make_text("Debug mode enabled. Use '/db_help' for debug commands.","",AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
+				mgr.console.add(BaseConsole.make_text(
+						"Debug mode enabled. Use '/db_help' for debug commands.",
+						"",
+						AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			mgr.console.add_header_spacing()))

--- a/godot_ap/managers/command_manager.gd
+++ b/godot_ap/managers/command_manager.gd
@@ -23,7 +23,7 @@ var debug_hidden := true :
 
 ## Contains an array of [Callable]s to be called when no [ConsoleCommand] is registered for a
 ## submitted command message.
-## [br]
+## [br][br]
 ## Elements should take a [CommandManager] for the first parameter and a [String] for the second.
 ## Returned values will be ignored.
 var default_procs: Array[Callable] 
@@ -84,8 +84,8 @@ func register_command(cmd: ConsoleCommand) -> void:
 
 ## Register a [Callable] to be used when no [ConsoleCommand] is found for a given command.
 ## See also [member default_procs].
-## [br]
-## [param proc] should take [CommandManager] for the first parameter and a [String] for the second.
+## [br][br]
+## [param proc] should take a [CommandManager] for the first parameter and a [String] for the second.
 ## The second parameter will contain the message to be handled.
 func register_default(proc: Callable) -> void:
 	default_procs.append(proc)
@@ -111,7 +111,7 @@ func call_cmd(msg: String) -> void:
 
 
 ## Get the registered [ConsoleCommand]s.
-## [br]
+## [br][br]
 ## [b]Do not mutate the returned array[/b]
 func get_commands() -> Array[ConsoleCommand]: # don't mutate the return
 	return _commands
@@ -143,7 +143,7 @@ func get_debug_commands() -> Array[ConsoleCommand]:
 
 
 ## Set up the basic [ConsoleCommand]s that will always be available.
-## [br]
+## [br][br]
 ## Currently this sets up [code]/help[/code] for displaying available commands, [code]/cls[/code] 
 ## for clearing the console, and [code]/clr_hist[/code] for clearing the command history.
 func setup_basic_commands() -> void:
@@ -175,7 +175,7 @@ func setup_basic_commands() -> void:
 
 
 ## Set up the [ConsoleCommand]s that will only be available when debug mode is enabled.
-## [br]
+## [br][br]
 ## If [method OS.is_debug_build] returns false, no commands will be set up.
 func setup_debug_commands() -> void:
 	if not OS.is_debug_build():

--- a/godot_ap/managers/command_manager.gd
+++ b/godot_ap/managers/command_manager.gd
@@ -99,9 +99,7 @@ func call_cmd(msg: String) -> void:
 	var cmd := get_command(msg.split(" ", true, 1)[0])
 	if cmd and cmd.call_proc:
 		if cmd.is_disabled():
-			console.add(BaseConsole.make_text(
-					"Command '%s' is disabled!" % cmd.text,
-					"",
+			console.add(BaseConsole.make_text("Command '%s' is disabled!" % cmd.text, "",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 		else:
 			cmd.call_proc.call(self, cmd, msg)
@@ -158,8 +156,9 @@ func setup_basic_commands() -> void:
 			mgr.console.add(folder)
 			folder.add(mgr.console.make_header_spacing())
 			for cmd in mgr.get_commands().filter(func(cmd):
-				return not (cmd.is_disabled() or cmd.is_debug())):
+					return not (cmd.is_disabled() or cmd.is_debug())):
 				cmd.output_helptext(mgr.console, folder)
+			
 			mgr.console.add_header_spacing()
 			folder.fold(false)))
 	
@@ -185,9 +184,7 @@ func setup_debug_commands() -> void:
 		.add_help("", "Displays this message")
 		.set_call(func(mgr: CommandManager, _cmd: ConsoleCommand, _msg: String):
 			mgr.console.add_header_spacing()
-			mgr.console.add(BaseConsole.make_text(
-					"Debug Help:",
-					"",
+			mgr.console.add(BaseConsole.make_text("Debug Help:", "",
 					AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			for cmd in mgr.get_commands().filter(func(cmd):
 				return not cmd.is_disabled() and cmd.is_debug()):
@@ -199,9 +196,7 @@ func setup_debug_commands() -> void:
 			debug_hidden = not debug_hidden
 			mgr.console.add_header_spacing()
 			if debug_hidden:
-				mgr.console.add(BaseConsole.make_text(
-						"Debug mode disabled",
-						"",
+				mgr.console.add(BaseConsole.make_text("Debug mode disabled", "",
 						AP.ComplexColor.as_special(AP.SpecialColor.UI_MESSAGE)))
 			else:
 				mgr.console.add(BaseConsole.make_text(

--- a/godot_ap/managers/configs.gd
+++ b/godot_ap/managers/configs.gd
@@ -1,35 +1,55 @@
-class_name APConfigManager extends Node
+class_name APConfigManager
+extends Node
+## Configuration management for GodotAP.
 
+## Emits when configuration is changed.
 @warning_ignore("unused_signal")
 signal config_changed
+
+## Configuration file format version.
 const CFG_VERSION: int = 1
+
+## Configuration file header.
 const CONFIG_HEADER := "GodotAP Settings File"
 
 var _pause_saving := false
+
+# NOTE: Is currently unused. Consequently, I (the person writing the documentation) can't write
+# documentation for this, as I don't know what it's meant to do. 
 var is_tracking := false :
 	set(val):
 		if val != is_tracking:
 			is_tracking = val
 			save_cfg()
 			config_changed.emit()
+
+# NOTE: Is currently unused. Consequently, I (the person writing the documentation) can't write
+# documentation for this, as I don't know what it's meant to do.
 var verbose_trackerpack := false :
 	set(val):
 		if val != verbose_trackerpack:
 			verbose_trackerpack = val
 			save_cfg()
 			config_changed.emit()
+
+# NOTE: Is currently unused. Consequently, I (the person writing the documentation) can't write
+# documentation for this, as I don't know what it's meant to do.
 var hide_finished_map_squares := false :
 	set(val):
 		if val != hide_finished_map_squares:
 			hide_finished_map_squares = val
 			save_cfg()
 			config_changed.emit()
+
+## Path to the [Theme] to use for the console.
 var window_theme_path: String :
 	set(val):
 		if val != window_theme_path:
 			window_theme_path = val
 			save_cfg()
 			config_changed.emit()
+
+## Client UUID.
 var uuid: String :
 	set(val):
 		if val != uuid:
@@ -37,6 +57,8 @@ var uuid: String :
 			save_cfg()
 			config_changed.emit()
 
+
+## Generate a version 4 UUID.
 static func generate_uuid() -> String:
 	var ret := ""
 	for q in 8:
@@ -57,11 +79,14 @@ static func generate_uuid() -> String:
 		ret += String.num_int64(randi_range(0, 16), 16, true)
 	return ret
 
+
 func _ready():
 	load_cfg()
 	if not uuid:
 		uuid = generate_uuid()
 
+
+## Load config from persistent user data. Returns [code]true[/code] if successful.
 func load_cfg() -> bool:
 	DirAccess.make_dir_recursive_absolute("user://ap/")
 	var file: FileAccess = FileAccess.open("user://ap/settings.dat", FileAccess.READ)
@@ -72,12 +97,17 @@ func load_cfg() -> bool:
 	file.close()
 	_pause_saving = false
 	return ret
+
+
+## Save config to persistent user data.
 func save_cfg() -> void:
-	if _pause_saving: return
+	if _pause_saving:
+		return
 	DirAccess.make_dir_recursive_absolute("user://ap/")
 	var file: FileAccess = FileAccess.open("user://ap/settings.dat", FileAccess.WRITE)
 	_save_cfg(file)
 	file.close()
+
 
 func _load_cfg(file: FileAccess) -> bool:
 	if file.get_pascal_string() != CONFIG_HEADER:
@@ -92,13 +122,18 @@ func _load_cfg(file: FileAccess) -> bool:
 	if vers >= 1:
 		uuid = file.get_pascal_string()
 	return true
+
+
 func _save_cfg(file: FileAccess):
 	file.store_pascal_string(CONFIG_HEADER)
 	file.store_32(CFG_VERSION)
 	var byte = 0
-	if is_tracking: byte |= 0b00000001
-	if verbose_trackerpack: byte |= 0b00000010
-	if hide_finished_map_squares: byte |= 0b00000100
+	if is_tracking:
+		byte |= 0b00000001
+	if verbose_trackerpack:
+		byte |= 0b00000010
+	if hide_finished_map_squares:
+		byte |= 0b00000100
 	file.store_8(byte)
 	file.store_pascal_string(window_theme_path)
 	# CFG_VERSION >= 1

--- a/godot_ap/managers/gui.gd
+++ b/godot_ap/managers/gui.gd
@@ -1,5 +1,6 @@
 class_name GUI
 
+## Create a checkbox with a label and a callback.
 static func make_cbox_row(s: String, initial_state: bool, proc: Callable) -> HBoxContainer:
 	var hbox := HBoxContainer.new()
 	hbox.set_anchors_preset(Control.PRESET_CENTER)

--- a/godot_ap/managers/saves.gd
+++ b/godot_ap/managers/saves.gd
@@ -73,7 +73,7 @@ func _ready() -> void:
 						Archipelago.ap_reconnect_to_save()))
 
 
-## Write save data to [SaveFile] on disk at index [member open_save_ind]
+## Write save data to [SaveFile] on disk at index [member open_save_ind].
 func save() -> void:
 	write_save(open_save_ind)
 

--- a/godot_ap/managers/saves.gd
+++ b/godot_ap/managers/saves.gd
@@ -1,6 +1,10 @@
 class_name APSaveManager 
 extends Node
 ## Save file manager.
+##
+## Manages saving information stored in [SaveFile] instances to disk. If more information should be
+## saved to disk, extend this class and override [method make_save_file] to return a subclass of
+## [SaveFile] with the desired extra information.
 
 ## Header for save files.
 @export var SAVE_HEADER: String = "GodotAP_Save_File"

--- a/godot_ap/managers/saves.gd
+++ b/godot_ap/managers/saves.gd
@@ -1,15 +1,26 @@
-class_name APSaveManager extends Node
+class_name APSaveManager 
+extends Node
+## Save file manager.
 
+## Header for save files.
 @export var SAVE_HEADER: String = "GodotAP_Save_File"
+
+## Currently open save file.
 var open_save: SaveFile
+
+## Index number of the currently open save file.
 var open_save_ind := -1
 
-func make_save_file() -> SaveFile: ## Override to return a subclass of SaveFile
+
+## Create a new save file.
+func make_save_file() -> SaveFile: 
 	return SaveFile.new()
+
 
 func _init() -> void:
 	open_save = make_save_file()
 	DirAccess.make_dir_recursive_absolute("user://saves/")
+
 
 func _ready() -> void:
 	if OS.is_debug_build(): # Debug commands for forcibly saving/loading via console
@@ -19,23 +30,37 @@ func _ready() -> void:
 				var command_args = msg.split(" ", true, 2)
 				if command_args.size() == 1:
 					save()
-				elif command_args.size() != 2 or not command_args[1].is_valid_int() or int(command_args[1]) < 0:
-					cmd.output_usage(mgr.console)
+				elif (
+						command_args.size() != 2 
+						or not command_args[1].is_valid_int() 
+						or int(command_args[1]) < 0
+				):
+						cmd.output_usage(mgr.console)
 				else:
 					write_save(int(command_args[1]))))
+		
 		Archipelago.cmd_manager.register_command(ConsoleCommand.new("/delsave").debug()
 			.add_help("num", "Deletes the specified save file. num >= 0.")
 			.set_call(func(mgr: CommandManager, cmd: ConsoleCommand, msg: String):
 				var command_args = msg.split(" ", true, 2)
-				if command_args.size() != 2 or not command_args[1].is_valid_int() or int(command_args[1]) < 0:
+				if (
+						command_args.size() != 2 
+						or not command_args[1].is_valid_int() 
+						or int(command_args[1]) < 0
+				):
 					cmd.output_usage(mgr.console)
 				else:
 					delete_save(int(command_args[1]))))
+		
 		Archipelago.cmd_manager.register_command(ConsoleCommand.new("/loadsave").debug()
 			.add_help("num", "Loads the specified save file. num >= 0.")
 			.set_call(func(mgr: CommandManager, cmd: ConsoleCommand, msg: String):
 				var command_args = msg.split(" ", true, 2)
-				if command_args.size() != 2 or not command_args[1].is_valid_int() or int(command_args[1]) < 0:
+				if (
+						command_args.size() != 2 
+						or not command_args[1].is_valid_int() 
+						or int(command_args[1]) < 0
+				):
 					cmd.output_usage(mgr.console)
 				else:
 					var is_conn: bool = Archipelago.status != AP.APStatus.DISCONNECTED
@@ -47,15 +72,23 @@ func _ready() -> void:
 					if is_conn:
 						Archipelago.ap_reconnect_to_save()))
 
+
+## Write save data to [SaveFile] on disk at index [member open_save_ind]
 func save() -> void:
 	write_save(open_save_ind)
 
+
+## Read save file at index [param ind] from disk. [param ind] must be greater than 0.
+## Returns [code]true[/code] if read is successful. Save will be assigned to [member open_save] if
+## successful.
 func read_save(ind: int) -> bool:
-	if ind < 0: return false
+	if ind < 0:
+		return false
 	var file: FileAccess = FileAccess.open("user://saves/%d.dat" % ind, FileAccess.READ)
 	if not file or file.get_pascal_string() != SAVE_HEADER:
 		var f2 = FileAccess.open("user://saves/%d.dat" % ind, FileAccess.WRITE)
-		if not f2: return false
+		if not f2:
+			return false
 		f2.close()
 		open_save.clear()
 	else:
@@ -67,13 +100,19 @@ func read_save(ind: int) -> bool:
 	Archipelago.aplock = open_save.aplock
 	return true
 
+
+## Write save file to save at index [param ind] on disk. [param ind] must be greater than 0.
+## Returns [code]true[/code] if successful.
 func write_save(ind: int) -> bool:
-	if ind < 0: return false
+	if ind < 0:
+		return false
 	var file: FileAccess = FileAccess.open("user://saves/%d.dat" % ind, FileAccess.WRITE)
 	file.store_pascal_string(SAVE_HEADER)
 	open_save.write(file)
 	file.close()
 	return true
 
+
+## Delete save file at index [param ind] from disk.
 func delete_save(ind: int):
 	DirAccess.remove_absolute("user://saves/%d.dat" % ind)

--- a/godot_ap/managers/saves.gd
+++ b/godot_ap/managers/saves.gd
@@ -78,7 +78,7 @@ func save() -> void:
 	write_save(open_save_ind)
 
 
-## Read save file at index [param ind] from disk. [param ind] must be greater than 0.
+## Read save file at index [param ind] from disk. [param ind] must be nonnegative.
 ## Returns [code]true[/code] if read is successful. Save will be assigned to [member open_save] if
 ## successful.
 func read_save(ind: int) -> bool:
@@ -101,7 +101,7 @@ func read_save(ind: int) -> bool:
 	return true
 
 
-## Write save file to save at index [param ind] on disk. [param ind] must be greater than 0.
+## Write save file to save at index [param ind] on disk. [param ind] must be nonnegative.
 ## Returns [code]true[/code] if successful.
 func write_save(ind: int) -> bool:
 	if ind < 0:

--- a/godot_ap/save_file.gd
+++ b/godot_ap/save_file.gd
@@ -1,7 +1,7 @@
 class_name SaveFile
 ## GodotAP connection & session save file.
 
-## Information that's locked to a room.
+## A room lock, preventing the save from connecting to the wrong room once locked.
 var aplock: APLock = APLock.new()
 ## Room connection information.
 var creds: APCredentials = APCredentials.new()

--- a/godot_ap/save_file.gd
+++ b/godot_ap/save_file.gd
@@ -1,8 +1,14 @@
 class_name SaveFile
+## GodotAP connection & session save file.
 
+## Information that's locked to a room.
 var aplock: APLock = APLock.new()
+## Room connection information.
 var creds: APCredentials = APCredentials.new()
 
+
+## Read save from file on disk. Returns [code]true[/code] if successful, [code]false[/code]
+## otherwise.
 func read(file: FileAccess) -> bool:
 	if not aplock.read(file):
 		return false
@@ -12,6 +18,9 @@ func read(file: FileAccess) -> bool:
 		return false
 	return true
 
+
+## Write save to file on disk. Returns [code]true[/code] if successful, [code]false[/code]
+## otherwise.
 func write(file: FileAccess) -> bool:
 	if not aplock.write(file):
 		return false
@@ -19,6 +28,8 @@ func write(file: FileAccess) -> bool:
 		return false
 	return true
 
+
+## Clear currently loaded save information.
 func clear() -> void:
 	aplock = APLock.new()
 	creds = APCredentials.new()


### PR DESCRIPTION
I was fiddling around with something and wanted to use this library, but found it hard to understand and read, so I have added a bunch of documentation and made the formatting more consistent and readable. I mainly followed the [recommended GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html), except where an alternative style was consistently used and readable. I also broke up as many lines that went over 100 characters as I could, excluding some long strings.

This PR doesn't include documentation for the main UI and app code, only for the files in the `ap_files`, `autoloads`, and `managers` directories, and `save_file.gd`. Any non-documentation changes should have no functional differences, only changes to formatting.

No AI was used in the work done here, I'm just like this.